### PR TITLE
Updating set-aia-settings log out variable to consoleport as managerf…

### DIFF
--- a/DeepSecurity/Common/Scripts/set-aia-settings.sh
+++ b/DeepSecurity/Common/Scripts/set-aia-settings.sh
@@ -78,5 +78,5 @@ echo -e "policyid for Deep Security Virtual Appliance Policy is $policyid\n" >> 
 
 
 ## log out
-curl -k -X DELETE https://localhost:$3/rest/authentication/logout?sID="$SID"
+curl -k -X DELETE https://localhost:$4/rest/authentication/logout?sID="$SID"
 exit 


### PR DESCRIPTION
set-aia-settings takes the console port as the 4th parameter.

```
## set-aia-settings <user> <pass> <elbfqdn> <consoleport>
user=$1
pass=$2
managerfqdn=$3
consoleport=$4
manager=localhost:${4}
```

The log out curl incorrectly references the 3rd parameter (managerfqdn).