### PR TITLE
Removing hardcoded load balancer port from create-console-listener

### DIFF
--- a/DeepSecurity/Common/Scripts/create-console-listener.sh
+++ b/DeepSecurity/Common/Scripts/create-console-listener.sh
@@ -33,4 +33,4 @@ done
 echo 'load balancer listener created'
 
 aws elb create-load-balancer-policy --load-balancer-name $1 --policy-name DSMConsoleStickySessions --policy-type-name LBCookieStickinessPolicyType --region $6 --policy-attributes AttributeName=CookieExpirationPeriod,AttributeValue=600
-aws elb set-load-balancer-policies-of-listener --load-balancer-name $1 --load-balancer-port 443 --policy-names DSMConsoleStickySessions --region $6
+aws elb set-load-balancer-policies-of-listener --load-balancer-name $1 --load-balancer-port $3 --policy-names DSMConsoleStickySessions --region $6


### PR DESCRIPTION
create-console-listener takes the load balancer port as the 3rd parameter.

```
#!/bin/bash
## create listenter on elb
## createlistener <elb name> <elb fqdn> <dsm console port> <StackName> <firstelb>
```

The set-load-balancer command is hardcoded to 443. As such, the command fails if using a custom port (e.g. the default value of the DSMMP template is 4119). Removing 443 and updating with $3 variable as per the create-load-balancer-listeners command.