### PR TITLE
Updated templates to version 5.7

### DIFF
--- a/templates/common/db/ds-db-abstract.template
+++ b/templates/common/db/ds-db-abstract.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: This template is an abstraction layer for choosing PostgreSQL,
+Description: 'v5.7: This template is an abstraction layer for choosing PostgreSQL,
   Oracle or MSSQL when deploying Deep Security Manager. (qs-1ngr590i4)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-mssql-rds.template
+++ b/templates/common/db/ds-db-mssql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: This template deploys an MSSQL RDS Instance for Deep Security
+Description: 'v5.7: This template deploys an MSSQL RDS Instance for Deep Security
   Manager. (qs-1ngr590ij)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-oracle-rds.template
+++ b/templates/common/db/ds-db-oracle-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: This template deploys an Oracle RDS instance for Deep Security
+Description: 'v5.7: This template deploys an Oracle RDS instance for Deep Security
   Manager. (qs-1ngr590i9)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-postgresql-rds.template
+++ b/templates/common/db/ds-db-postgresql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: This template deploys a PostgreSQL RDS instance for Deep Security
+Description: 'v5.7: This template deploys a PostgreSQL RDS instance for Deep Security
   Manager. (qs-1ngr590ie)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/dsm-elb.template
+++ b/templates/common/dsm-elb.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: Deploys Elastic Load Balancers and Security Groups for Deep Security
+Description: 'v5.7: Deploys Elastic Load Balancers and Security Groups for Deep Security
   (qs-1ngr590je). Manager.'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/ds-elb-sg.template
+++ b/templates/common/security-groups/ds-elb-sg.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: This template creates security groups for the ELB for Deep Security
+Description: 'v5.7: This template creates security groups for the ELB for Deep Security
   Manager. (qs-1ngr590io)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-security-group.template
+++ b/templates/common/security-groups/dsm-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: This template creates the security group to allow inbound communication
+Description: 'v5.7: This template creates the security group to allow inbound communication
   to Deep Security Manager. (qs-1ngr590iu)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-sg-ingress-rules.template
+++ b/templates/common/security-groups/dsm-sg-ingress-rules.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: This template creates the ingress rules for Deep Security Managers.
+Description: 'v5.7: This template creates the ingress rules for Deep Security Managers.
   (qs-1ngr590j4)'
 Parameters:
   DSMSG:

--- a/templates/common/security-groups/rds-security-group.template
+++ b/templates/common/security-groups/rds-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: This template creates the security group to allow communication
+Description: 'v5.7: This template creates the security group to allow communication
   from Deep Security Managers to their RDS Instance. (qs-1ngr590j9)'
 Parameters:
   AWSIVPC:

--- a/templates/common/sps.template
+++ b/templates/common/sps.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.6: Smart protection server template (qs-1ngr590jj).
+  v5.7: Smart protection server template (qs-1ngr590jj).
 Parameters:
   AWSIKeyPairName:
     Description: Existing key pair to use for connecting to your Smart Protection Server

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.7: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'
@@ -211,52 +211,54 @@ Parameters:
     Default: ''
 Mappings:
   DSMAMI:
-    us-east-1:
-      PerHost: ami-a394f0d9
-      BYOL: ami-c18befbb
-    us-east-2:
-      PerHost: ami-07012862
-      BYOL: ami-560e2733
-    us-west-1:
-      PerHost: ami-12d9e372
-      BYOL: ami-fed8e29e
-    us-west-2:
-      PerHost: ami-ed76ad95
-      BYOL: ami-9972a9e1
-    ca-central-1:
-      PerHost: ami-1c1aa178
-      BYOL: ami-cc269da8
     ap-south-1:
-      PerHost: ami-26723b49
-      BYOL: ami-09743d66
-    ap-northeast-2:
-      PerHost: ami-3ad17754
-      BYOL: ami-3ad17754
-    ap-southeast-1:
-      PerHost: ami-ffebb79c
-      BYOL: ami-cbeab6a8
-    ap-southeast-2:
-      PerHost: ami-dece3abc
-      BYOL: ami-ebcf3b89
+      PerHost: ami-dc8ed8b3
+      BYOL: ami-839bcbec
+    us-east-1:
+      PerHost: ami-e9f1df93
+      BYOL: ami-b5dde7cf
+    us-east-2:
+      PerHost: ami-13e6cc76
+      BYOL: ami-55192c30
     ap-northeast-1:
-      PerHost: ami-04f77362
-      BYOL: ami-0af5716c
-    eu-central-1:
-      PerHost: ami-16af2179
-      BYOL: ami-c1911fae
-    eu-west-1:
-      PerHost: ami-f71ba48e
-      BYOL: ami-611aa518
-    eu-west-2:
-      PerHost: ami-222f3146
-      BYOL: ami-8e2f31ea
-    eu-west-3:
-      BYOL: ami-1364d36e
+      PerHost: ami-1a3e5f7c
+      BYOL: ami-9a6800fc
     sa-east-1:
-      PerHost: ami-f02d6a9c
-      BYOL: ami-f02d6a9c
+      PerHost: ami-7585c819
+      BYOL: ami-d8145bb4
+    ap-northeast-2:
+      PerHost: ami-c3e546ad
+      BYOL: ami-c1298aaf
+    ap-southeast-1:
+      PerHost: ami-54ef9028
+      BYOL: ami-d0b4f1ac
+    ca-central-1:
+      PerHost: ami-fc61e498
+      BYOL: ami-21d25645
+    ap-southeast-2:
+      PerHost: ami-95d926f7
+      BYOL: ami-e1659c83
+    us-west-2:
+      PerHost: ami-f0f44688
+      BYOL: ami-4374cc3b
+    us-west-1:
+      PerHost: ami-1fe7e57f
+      BYOL: ami-33fbf753
+    eu-central-1:
+      PerHost: ami-9666f9f9
+      BYOL: ami-49158e26
+    eu-west-1:
+      PerHost: ami-c066feb9
+      BYOL: ami-93197bea
+    eu-west-2:
+      PerHost: ami-06f3e862
+      BYOL: ami-24ddc740
+    eu-west-3:
+      PerHost: ami-65eb5d18
+      BYOL: ami-4eb40233
     us-gov-west-1:
       BYOL: ami-5bc8463a
+      PerHost: ami-efaa238e
   DSMSIZE:
     us-east-1:
       PerHost: m4.xlarge
@@ -298,11 +300,13 @@ Mappings:
       PerHost: m4.xlarge
       BYOL: m4.xlarge
     eu-west-3:
+      PerHost: r4.xlarge
       BYOL: r4.xlarge
     sa-east-1:
       PerHost: m4.xlarge
       BYOL: m4.xlarge
     us-gov-west-1:
+      PerHost: m4.xlarge
       BYOL: m4.xlarge
   DSMDBMap:
     SQL:
@@ -338,7 +342,7 @@ Resources:
           Statement:
           - Effect: Allow
             Action:
-              - s3:GetObject
+            - s3:GetObject
             Resource:
               Fn::Sub:
               - arn:${Partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.7: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.6: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.7: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ Oracle RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.6: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.7: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS
@@ -202,6 +202,16 @@ Mappings:
       '2': m4.large
       '3': m4.xlarge
       '4': m4.xlarge
+    eu-west-3:
+      '1': r4.large
+      '2': r4.large
+      '3': r4.xlarge
+      '4': r4.xlarge
+    us-gov-west-1:
+      '1': m4.large
+      '2': m4.large
+      '3': m4.xlarge
+      '4': m4.xlarge
   RDSStorageSize:
     1-100:
       Size: '50'
@@ -282,6 +292,16 @@ Mappings:
       '2': db.m3.large
       '3': db.m3.xlarge
       '4': db.m3.xlarge
+    eu-west-3:
+      '1': db.r4.large
+      '2': db.r4.large
+      '3': db.r4.xlarge
+      '4': db.r4.xlarge
+    us-gov-west-1:
+      '1': db.m3.large
+      '2': db.m3.large
+      '3': db.m3.xlarge
+      '4': db.m3.xlarge
   DeploymentSize:
     1-100:
       Size: '1'
@@ -350,15 +370,14 @@ Resources:
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
 Conditions:
   PerHostSupportedRegion:
-    !Not [!Or [Condition: GovCloudCondition, Condition: ParisCondition]]
+    !Not
+    - !Equals
+      - !Ref AWS::Region
+      - match-all-regions
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
-  ParisCondition:
       !Equals
       - !Ref AWS::Region
-      - eu-west-3
+      - us-gov-west-1
 Outputs:
   DeepSecurityConsole:
     Value: !GetAtt MasterMP.Outputs.DeepSecurityConsole

--- a/templates/quickstart/trendmicro-deepsecurity-poc.template
+++ b/templates/quickstart/trendmicro-deepsecurity-poc.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.6: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.7: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ Oracle RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-rhel.template
+++ b/templates/quickstart/trendmicro-deepsecurity-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.6: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.7: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-tp.template
+++ b/templates/quickstart/trendmicro-deepsecurity-tp.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.6: Quick Start that deploys a new VPC with Trend Micro Deep Security
+  v5.7: Quick Start that deploys a new VPC with Trend Micro Deep Security
   **WARNING** This template uses images from the AWS Marketplace and an active
   subscription is required - Please see the Quick Start documentation for more
   details. You will be billed for the AWS resources used if you create a stack

--- a/templates/rhel/dsm-rhel.template
+++ b/templates/rhel/dsm-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.6: Deploys Deep Security Manager to AWS. This template is designed to be
+  v5.7: Deploys Deep Security Manager to AWS. This template is designed to be
   nested in a stack, and requires several passed parameters to launch.
   **WARNING** This template creates Amazon EC2 instances and related resources.
   You will be billed for the AWS resources used if you create a stack from this
@@ -428,39 +428,39 @@ Resources:
               command: mkdir /opt/dsm/; echo -Xmx12g >> /opt/dsm/dsm_s.vmoptions
         prepDSMInstall:
           files:
-            /tmp/Manager-Linux-10.2.306.x64.sh:
+            /tmp/Manager-Linux-10.3.102.x64.sh:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/10.2/Manager-Linux-10.2.306.x64.sh
+                https://files.trendmicro.com/products/deepsecurity/en/10.3/Manager-Linux-10.3.102.x64.sh
               owner: root
               mode: '000700'
-            /tmp/Agent-RedHat_EL6-10.2.0-340.x86_64.zip:
+            /tmp/Agent-RedHat_EL6-10.3.0-127.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/10.2/Agent-RedHat_EL6-10.2.0-340.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/10.3/Agent-RedHat_EL6-10.3.0-127.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-RedHat_EL6-10.2.0-350.x86_64.zip:
+            /tmp/KernelSupport-RedHat_EL6-10.3.0-175.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/10.2/KernelSupport-RedHat_EL6-10.2.0-350.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/10.3/KernelSupport-RedHat_EL6-10.3.0-175.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/Agent-RedHat_EL7-10.2.0-340.x86_64.zip:
+            /tmp/Agent-RedHat_EL7-10.3.0-127.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/10.2/Agent-RedHat_EL7-10.2.0-340.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/10.3/Agent-RedHat_EL7-10.3.0-127.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-RedHat_EL7-10.2.0-358.x86_64.zip:
+            /tmp/KernelSupport-RedHat_EL7-10.3.0-168.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/10.2/KernelSupport-RedHat_EL7-10.2.0-358.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/10.3/KernelSupport-RedHat_EL7-10.3.0-168.x86_64.zip
               owner: root
               mode: '000600'
             /tmp/Agent-Ubuntu_16.04-10.2.0-340.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/10.2/Agent-Ubuntu_16.04-10.2.0-340.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/10.3/Agent-Ubuntu_16.04-10.3.0-127.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-Ubuntu_16.04-10.2.0-370.x86_64.zip:
+            /tmp/KernelSupport-Ubuntu_16.04-10.3.0-165.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/10.2/KernelSupport-Ubuntu_16.04-10.2.0-370.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/10.3/KernelSupport-Ubuntu_16.04-10.3.0-165.x86_64.zip
               owner: root
               mode: '000600'
             /tmp/Agent-Ubuntu_14.04-10.0.0-2094.x86_64.zip:
@@ -473,19 +473,19 @@ Resources:
                 http://files.trendmicro.com/products/deepsecurity/en/10.0/KernelSupport-Ubuntu_14.04-10.0.0-2114.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/Agent-amzn1-10.2.0-340.x86_64.zip:
+            /tmp/Agent-amzn1-10.3.0-127.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/10.2/Agent-amzn1-10.2.0-340.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/10.3/Agent-amzn1-10.3.0-127.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-amzn1-10.2.0-342.x86_64.zip:
+            /tmp/KernelSupport-amzn1-10.3.0-152.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/10.2/KernelSupport-amzn1-10.2.0-342.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/10.3/KernelSupport-amzn1-10.3.0-152.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/Agent-Windows-10.2.0-340.x86_64.zip:
+            /tmp/Agent-Windows-10.3.0-128.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/10.2/Agent-Windows-10.2.0-340.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/10.3/Agent-Windows-10.3.0-128.x86_64.zip
               owner: root
               mode: '000600'
             /etc/cfn/dsmConfiguration.properties:
@@ -601,7 +601,7 @@ Resources:
               ignoreErrors: 'false'
             1-install-DSM:
               command: >-
-                cd /tmp; sh Manager-Linux-10.2.306.x64.sh -q -console -varfile
+                cd /tmp; sh Manager-Linux-10.3.102.x64.sh -q -console -varfile
                 /etc/cfn/dsmConfiguration.properties >> /tmp/dsmInstallLog
               ignoreErrors: 'false'
             2-fix-for-systemd:

--- a/templates/rhel/master-rhel.template
+++ b/templates/rhel/master-rhel.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.6: Trend Micro Deep Security AWS RHEL master template.'
+Description: 'v5.7: Trend Micro Deep Security AWS RHEL master template.'
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:


### PR DESCRIPTION
- 10.3 Updated AMIs for commercial (GovCloud is still at 10.2)
- Added PerHost for GovCloud, Paris
- Update RHEL templates for 10.3