### PR TITLE
Adding missing sts:AssumeRole

### DIFF
--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -368,6 +368,7 @@ Resources:
               - ec2:DescribeAvailabilityZones
               - ec2:DescribeSecurityGroups
               - iam:ListAccountAliases
+              - sts:AssumeRole
               Resource: '*'
             - Effect: Allow
               Action:


### PR DESCRIPTION
The IAM policy attached to the DSMRole is missing the sts:AssumeRole permission.