### PR TITLE
Updated templates to version 5.15

### DIFF
--- a/templates/common/db/ds-db-abstract.template
+++ b/templates/common/db/ds-db-abstract.template
@@ -1,8 +1,15 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: This template is an abstraction layer for choosing PostgreSQL,
+Description: 'v5.15: This template is an abstraction layer for choosing PostgreSQL,
   Oracle or MSSQL when deploying Deep Security Manager. (qs-1ngr590i4)'
 Parameters:
+  AWSIKeyPairName:
+    Description: Existing key pair to use for connecting to database if using Postgres on Docker
+      Instance
+    Type: AWS::EC2::KeyPair::KeyName
+    MinLength: '1'
+    MaxLength: '255'
+    ConstraintDescription: Select an existing EC2 Key Pair.
   DBIRDSInstanceSize:
     Default: db.m3.large
     Description: Trend Micro Deep Security Database instance class
@@ -79,6 +86,7 @@ Parameters:
     - SQL
     - Oracle
     - PostgreSQL
+    - PostgresDocker
   MultiAZ:
     Description: Use Multi-AZ or SQL Mirroring Option Group for RDS Instance
     Type: String
@@ -195,6 +203,26 @@ Resources:
       SubnetIds:
       - !Ref DBISubnet1
       - !Ref DBISubnet2
+  DSPostgreSQLDocker:
+    Type: AWS::CloudFormation::Stack
+    Condition: DBTypeIsPostgreSQLDocker
+    Properties:
+      TemplateURL:
+        Fn::Sub:
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/common/db/ds-db-postgresql-docker.template
+        - QSS3Region:
+            !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      TimeoutInMinutes: '15'
+      Parameters:
+        AWSIKeyPairName: !Ref AWSIKeyPairName
+        DBICAdminName: !Ref DBICAdminName
+        DBICAdminPassword: !Ref DBICAdminPassword
+        DBPName: !Ref DBPName
+        RDSSG: !Ref RDSSG
+        DBISubnet: !Ref DBISubnet1
 Conditions:
   DBTypeIsOracle:
     !Equals
@@ -208,6 +236,10 @@ Conditions:
     !Equals
     - !Ref DBPEngine
     - PostgreSQL
+  DBTypeIsPostgreSQLDocker:
+    !Equals
+    - !Ref DBPEngine
+    - PostgresDocker
   GovCloudCondition:
     !Equals
     - !Ref AWS::Region
@@ -221,7 +253,10 @@ Outputs:
       - !If
         - DBTypeIsPostgreSQL
         - !GetAtt DSPostgreSQLRDS.Outputs.DSDBEndpoint
-        - !GetAtt DSSQLRDS.Outputs.DSDBEndpoint
+        - !If
+          - DBTypeIsPostgreSQLDocker
+          - !GetAtt DSPostgreSQLDocker.Outputs.DSDBEndpoint
+          - !GetAtt DSSQLRDS.Outputs.DSDBEndpoint
   DSDBPort:
     Value:
       !If
@@ -230,5 +265,8 @@ Outputs:
       - !If
         - DBTypeIsPostgreSQL
         - !GetAtt DSPostgreSQLRDS.Outputs.DSDBPort
-        - !GetAtt DSSQLRDS.Outputs.DSDBPort
+        - !If
+          - DBTypeIsPostgreSQLDocker
+          - !GetAtt DSPostgreSQLDocker.Outputs.DSDBPort
+          - !GetAtt DSSQLRDS.Outputs.DSDBPort
 ...

--- a/templates/common/db/ds-db-mssql-rds.template
+++ b/templates/common/db/ds-db-mssql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: This template deploys an MSSQL RDS Instance for Deep Security
+Description: 'v5.15: This template deploys an MSSQL RDS Instance for Deep Security
   Manager. (qs-1ngr590ij)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-oracle-rds.template
+++ b/templates/common/db/ds-db-oracle-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: This template deploys an Oracle RDS instance for Deep Security
+Description: 'v5.15: This template deploys an Oracle RDS instance for Deep Security
   Manager. (qs-1ngr590i9)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-postgresql-docker.template
+++ b/templates/common/db/ds-db-postgresql-docker.template
@@ -1,0 +1,177 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: 'v5.15: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
+  This template deploys PostgreSQL on Docker for Deep Security Manager.'
+Parameters:
+  AWSIKeyPairName:
+    Description: Existing key pair to use for connecting to database instance
+      Instance
+    Type: AWS::EC2::KeyPair::KeyName
+    MinLength: '1'
+    MaxLength: '255'
+    ConstraintDescription: Select an existing EC2 Key Pair.
+  DBIRDSInstanceSize:
+    Default: db.m3.large
+    Description: Trend Micro Deep Security Database instance class
+    Type: String
+    AllowedValues:
+    - db.m4.medium
+    - db.m4.large
+    - db.m4.xlarge
+    - db.m4.2xlarge
+    - db.m3.medium
+    - db.m3.large
+    - db.m3.xlarge
+    - db.m3.2xlarge
+    - db.m2.xlarge
+    - db.r3.large
+    - db.r3.xlarge
+    - db.r3.2xlarge
+    - db.r3.4xlarge
+    - db.r3.8xlarge
+    - db.m2.2xlarge
+    - db.m2.4xlarge
+    - db.m1.medium
+    - db.m1.large
+    - db.m1.xlarge
+    - db.m4.large
+    - db.m4.xlarge
+    - db.r4.large
+    - db.r4.xlarge
+    ConstraintDescription: must select a valid database instance type.
+  DBICAdminName:
+    Default: dsadmin
+    Description: Admin account username to be used for the database instance
+    Type: String
+    MinLength: 1
+    MaxLength: 16
+    AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
+    ConstraintDescription: must begin with a letter and contain only alphanumeric
+      characters.
+  DBICAdminPassword:
+    NoEcho: true
+    Description: Password to be used for the Oracle database admin account
+    Type: String
+    MinLength: 8
+    MaxLength: 41
+    AllowedPattern: '[a-zA-Z0-9!^*\-_+]*'
+    ConstraintDescription: Can only contain alphanumeric characters or the following
+      special characters !^*-_+ Min length 8, max length 41
+  DBPName:
+    Default: dsm
+    Description: Name to be assigned to the database
+    Type: String
+    MinLength: 1
+    MaxLength: 64
+    AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
+    ConstraintDescription: must begin with a letter and contain only alphanumeric
+      characters.
+  RDSSG:
+    Type: AWS::EC2::SecurityGroup::Id
+  DBISubnet:
+    Type: String
+Mappings:
+  AWSAMIRegionMap:
+    AMI:
+      AMZNLINUXHVM: amzn-ami-hvm-2017.09.1.20180307-x86_64-gp2
+    ap-northeast-1:
+      AMZNLINUXHVM: ami-a77c30c1
+      InstanceType: m4.large
+    ap-northeast-2:
+      AMZNLINUXHVM: ami-5e1ab730
+      InstanceType: m4.large
+    ap-south-1:
+      AMZNLINUXHVM: ami-7c87d913
+      InstanceType: m4.large
+    ap-southeast-1:
+      AMZNLINUXHVM: ami-e2adf99e
+      InstanceType: m4.large
+    ap-southeast-2:
+      AMZNLINUXHVM: ami-43874721
+      InstanceType: m4.large
+    ca-central-1:
+      AMZNLINUXHVM: ami-5b55d23f
+      InstanceType: m4.large
+    eu-central-1:
+      AMZNLINUXHVM: ami-ac442ac3
+      InstanceType: m4.large
+    eu-west-1:
+      AMZNLINUXHVM: ami-3bfab942
+      InstanceType: m4.large
+    eu-west-2:
+      AMZNLINUXHVM: ami-dff017b8
+      InstanceType: m4.large
+    sa-east-1:
+      AMZNLINUXHVM: ami-5339733f
+      InstanceType: m4.large
+    us-east-1:
+      AMZNLINUXHVM: ami-1853ac65
+      InstanceType: m4.large
+    us-east-2:
+      AMZNLINUXHVM: ami-25615740
+      InstanceType: m4.large
+    us-gov-west-1:
+      AMZNLINUXHVM: ami-ffa61d9e
+      InstanceType: m4.large
+    us-west-1:
+      AMZNLINUXHVM: ami-bf5540df
+      InstanceType: m4.large
+    us-west-2:
+      AMZNLINUXHVM: ami-d874e0a0
+      InstanceType: m4.large
+Resources:
+  DSDatabase:
+    Type: AWS::EC2::Instance
+    Properties:
+      KeyName: !Ref AWSIKeyPairName
+      InstanceType:
+        !FindInMap
+        - AWSAMIRegionMap
+        - !Ref AWS::Region
+        - InstanceType
+      ImageId:
+        !FindInMap
+        - AWSAMIRegionMap
+        - !Ref AWS::Region
+        - AMZNLINUXHVM
+      NetworkInterfaces:
+        - DeviceIndex: '0'
+          SubnetId: !Ref DBISubnet
+          AssociatePublicIpAddress: true
+          GroupSet:
+          - !Ref RDSSG
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: 100
+            VolumeType: gp2
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash -xe
+
+          #Install Docker in the EC2 instance
+          sudo yum update -y
+          sudo yum install -y docker
+          sudo service docker start
+          sudo usermod -a -G docker ec2-user
+
+          docker pull postgres:9.6
+          docker run -e POSTGRES_PASSWORD=${DBICAdminPassword} -e POSTGRES_USER=${DBICAdminName} -p 5432:5432 -e POSTGRES_DB=${DBPName} --restart always --name dsm-psql -d postgres:9.6
+      Tags:
+      - Key: Application
+        Value: Deep Security Manager
+      - Key: Name
+        Value: Deep Security Database
+Conditions:
+  RegionIsUsGovCloud:
+    !Equals
+    - !Ref AWS::Region
+    - us-gov-west-1
+Outputs:
+  DSDBEndpoint:
+    Description: Endpoint to be passed to DSM installation properties file
+    Value: !GetAtt DSDatabase.PrivateIp
+  DSDBPort:
+    Description: Port to be passed to DSM installation properties file
+    Value: 5432
+...

--- a/templates/common/db/ds-db-postgresql-rds.template
+++ b/templates/common/db/ds-db-postgresql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: This template deploys a PostgreSQL RDS instance for Deep Security
+Description: 'v5.15: This template deploys a PostgreSQL RDS instance for Deep Security
   Manager. (qs-1ngr590ie)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/dsm-elb.template
+++ b/templates/common/dsm-elb.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: Deploys Elastic Load Balancers and Security Groups for Deep Security
+Description: 'v5.15: Deploys Elastic Load Balancers and Security Groups for Deep Security
   (qs-1ngr590je). Manager.'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/ds-elb-sg.template
+++ b/templates/common/security-groups/ds-elb-sg.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: This template creates security groups for the ELB for Deep Security
+Description: 'v5.15: This template creates security groups for the ELB for Deep Security
   Manager. (qs-1ngr590io)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-security-group.template
+++ b/templates/common/security-groups/dsm-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: This template creates the security group to allow inbound communication
+Description: 'v5.15: This template creates the security group to allow inbound communication
   to Deep Security Manager. (qs-1ngr590iu)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-sg-ingress-rules.template
+++ b/templates/common/security-groups/dsm-sg-ingress-rules.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: This template creates the ingress rules for Deep Security Managers.
+Description: 'v5.15: This template creates the ingress rules for Deep Security Managers.
   (qs-1ngr590j4)'
 Parameters:
   DSMSG:

--- a/templates/common/security-groups/rds-security-group.template
+++ b/templates/common/security-groups/rds-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: This template creates the security group to allow communication
+Description: 'v5.15: This template creates the security group to allow communication
   from Deep Security Managers to their RDS Instance. (qs-1ngr590j9)'
 Parameters:
   AWSIVPC:
@@ -17,6 +17,7 @@ Parameters:
     - SQL
     - Oracle
     - PostgreSQL
+    - PostgresDocker
   DSMSG:
     Type: AWS::EC2::SecurityGroup::Id
 Resources:
@@ -60,9 +61,13 @@ Conditions:
     - !Ref DBPEngine
     - SQL
   DBTypeIsPostgreSQL:
-    !Equals
-    - !Ref DBPEngine
-    - PostgreSQL
+    !Or
+    - !Equals
+      - !Ref DBPEngine
+      - PostgreSQL
+    - !Equals
+      - !Ref DBPEngine
+      - PostgresDocker
 Outputs:
   RDSSG:
     Value: !GetAtt RDSSG.GroupId

--- a/templates/common/sps.template
+++ b/templates/common/sps.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.14: Smart protection server template (qs-1ngr590jj).
+  v5.15: Smart protection server template (qs-1ngr590jj).
 Parameters:
   AWSIKeyPairName:
     Description: Existing key pair to use for connecting to your Smart Protection Server

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.15: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'
@@ -134,6 +134,7 @@ Parameters:
     - Oracle
     - SQL
     - PostgreSQL
+    - PostgresDocker
   DSISubnetID:
     Description: Existing Subnet for Deep Security Manager. Must be a public subnet
       contained the in VPC chosen above.
@@ -316,6 +317,8 @@ Mappings:
     Embedded:
       DbTypeString: Embedded
     PostgreSQL:
+      DbTypeString: PostgreSQL
+    PostgresDocker:
       DbTypeString: PostgreSQL
 Resources:
   DSMRole:
@@ -787,22 +790,10 @@ Resources:
               - Fn::Sub: ' --https-proxy https://${DSProxyUrl}'
               - ''
 Conditions:
-  DBTypeIsOracle:
-    !Equals
-    - !Ref DBPEngine
-    - Oracle
   DBTypeIsSQL:
     !Equals
     - !Ref DBPEngine
     - SQL
-  DBTypeIsEmbedded:
-    !Equals
-    - !Ref DBPEngine
-    - Embedded
-  DBTypeIsPostgreSQL:
-    !Equals
-    - !Ref DBPEngine
-    - PostgreSQL
   IsFirstNode:
     !Equals
     - !Ref DSMPMNode

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.15: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:
@@ -187,6 +187,7 @@ Parameters:
     - SQL
     - Oracle
     - PostgreSQL
+    - PostgresDocker
   DBPEndpoint:
     Type: String
     Description: If you have an existing oracle instance, enter the endpoint address
@@ -526,6 +527,7 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
+        AWSIKeyPairName: !Ref AWSIKeyPairName
         DBPName: !Ref DBPName
         DBIStorageAllocation: !Ref DBIStorageAllocation
         DBIRDSInstanceSize: !Ref DBIRDSInstanceSize

--- a/templates/quickstart/Infrastructure.template
+++ b/templates/quickstart/Infrastructure.template
@@ -1,7 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: >-
-  Template for testing the Quick Start, Creates the VPCs and subnets needed for
-  deployment
+Description: 'v5.15: Template for testing the Quick Start, Creates the VPCs
+  and subnets needed for deployment'
 Parameters:
   EnableDNSHostNames:
     Description: Enable DNS Host Names

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.14: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.15: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ RDS instance  **WARNING** This template uses
   images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS
@@ -86,13 +86,13 @@ Parameters:
     - PostgreSQL
   DatabaseSubnet1:
     Description: Select a private subnet for the RDS database.  Must be a private
-      subnet contained the in VPC chosen above.
+      subnet contained in the VPC chosen above.
     Type: AWS::EC2::Subnet::Id
     ConstraintDescription: RDS Subnet Groups must be comprised of 2 subnets in seperate
       availability zones within the specified VPC for deploying this template
   DatabaseSubnet2:
     Description: Select a second private subnet for the RDS database.  Must be a private
-      subnet contained the in VPC chosen above.
+      subnet contained in the VPC chosen above.
     Type: AWS::EC2::Subnet::Id
     ConstraintDescription: RDS Subnet Groups must be comprised of 2 subnets in seperate
       availability zones within the specified VPC for deploying this template
@@ -119,7 +119,7 @@ Parameters:
       special characters !^*-_+ Min length 8, max length 41
   DeepSecuritySubnet:
     Description: Select an existing Subnet for Deep Security Manager. Must be a public
-      subnet contained the in VPC chosen above.
+      subnet contained in the VPC chosen above.
     Type: AWS::EC2::Subnet::Id
     MinLength: '1'
     MaxLength: '255'

--- a/templates/quickstart/trendmicro-deepsecurity-demo.template
+++ b/templates/quickstart/trendmicro-deepsecurity-demo.template
@@ -1,10 +1,11 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.15: Quick Start that deploys Trend Micro Deep Security
-  into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
+Description: 'DEMO ONLY - v5.15: Demo of the Trend Micro Deep Security Quick Start.
+  This template creates the VPC infrastructure needed for the Quick Start and deploys an
+  EC2 instance with Docker and PostgreSQL for the database. **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS
-  resources used if you create a stack from this template. (qs-1ngr590k4)'
+  resources used if you create a stack from this template.'
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -14,14 +15,6 @@ Metadata:
       - DeepSecurityAdminName
       - DeepSecurityAdminPass
       - AWSKeyPairName
-      - ProtectedInstances
-    - Label:
-        default: Network Configuration
-      Parameters:
-      - AWSVPC
-      - DeepSecuritySubnet
-      - DatabaseSubnet1
-      - DatabaseSubnet2
     - Label:
         default: AWS Quick Start Configuration
       Parameters:
@@ -30,20 +23,10 @@ Metadata:
     ParameterLabels:
       AWSKeyPairName:
         default: EC2 Key Pair for SSH access
-      AWSVPC:
-        default: VPC for Deep Security Components
-      DeepSecuritySubnet:
-        default: Public Subnet for Deep Security Managers
       DeepSecurityAdminName:
         default: Administrator username for Deep Security
       DeepSecurityAdminPass:
         default: Administrator password for Deep Security
-      DatabaseSubnet1:
-        default: Primary private subnet for RDS
-      DatabaseSubnet2:
-        default: Secondary private subnet for RDS
-      ProtectedInstances:
-        default: Number of instances you expect to protect with Deep Security Agents
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3KeyPrefix:
@@ -56,32 +39,6 @@ Parameters:
     MinLength: '1'
     MaxLength: '255'
     ConstraintDescription: Select an existing EC2 Key Pair.
-  AWSVPC:
-    Description: Select an existing VPC to deploy Deep Security Manager.
-    Type: AWS::EC2::VPC::Id
-    MinLength: '1'
-    MaxLength: '255'
-    AllowedPattern: '[-_a-zA-Z0-9]*'
-  DatabaseSubnet1:
-    Description: Select a private subnet for the RDS database.  Must be a private
-      subnet contained in the VPC chosen above.
-    Type: AWS::EC2::Subnet::Id
-    ConstraintDescription: RDS Subnet Groups must be comprised of 2 subnets in seperate
-      availability zones within the specified VPC for deploying this template
-  DatabaseSubnet2:
-    Description: Select a second private subnet for the RDS database.  Must be a private
-      subnet contained in the VPC chosen above.
-    Type: AWS::EC2::Subnet::Id
-    ConstraintDescription: RDS Subnet Groups must be comprised of 2 subnets in seperate
-      availability zones within the specified VPC for deploying this template
-  DeepSecuritySubnet:
-    Description: Select an existing Subnet for Deep Security Manager. Must be a public
-      subnet contained in the VPC chosen above.
-    Type: AWS::EC2::Subnet::Id
-    MinLength: '1'
-    MaxLength: '255'
-    AllowedPattern: '[-_a-zA-Z0-9]*'
-    ConstraintDescription: Subnet ID must exist in the chosen VPC
   DeepSecurityAdminName:
     Default: MasterAdmin
     Description: The Deep Security Manager administrator username for Web Console
@@ -103,14 +60,6 @@ Parameters:
     AllowedPattern: '[a-zA-Z0-9!^*\-_+]*'
     ConstraintDescription: Can only contain alphanumeric characters or the following
       special characters !^*-_+ Min length 8, max length 41
-  ProtectedInstances:
-    Description: Select how many instances would you like to protect.
-    Type: String
-    AllowedValues:
-    - 1-100
-    - 101-500
-    - 501-1000
-    - 1001-2000
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: Quick Start bucket name can include numbers, lowercase
@@ -212,113 +161,15 @@ Mappings:
       '2': m4.large
       '3': m4.xlarge
       '4': m4.xlarge
-  RDSStorageSize:
-    1-100:
-      Size: '50'
-    101-500:
-      Size: '150'
-    501-1000:
-      Size: '200'
-    1001-2000:
-      Size: '300'
-  RDSInstanceSize:
-    us-east-1:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    us-east-2:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    us-west-1:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    us-west-2:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    ca-central-1:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    ap-south-1:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    ap-northeast-2:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    ap-southeast-1:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    ap-southeast-2:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    ap-northeast-1:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    eu-central-1:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    eu-west-1:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    eu-west-2:
-      '1': db.m4.large
-      '2': db.m4.large
-      '3': db.m4.xlarge
-      '4': db.m4.xlarge
-    sa-east-1:
-      '1': db.m3.large
-      '2': db.m3.large
-      '3': db.m3.xlarge
-      '4': db.m3.xlarge
-    eu-west-3:
-      '1': db.r4.large
-      '2': db.r4.large
-      '3': db.r4.xlarge
-      '4': db.r4.xlarge
-    us-gov-west-1:
-      '1': db.m3.large
-      '2': db.m3.large
-      '3': db.m3.xlarge
-      '4': db.m3.xlarge
-  DeploymentSize:
-    1-100:
-      Size: '1'
-    101-500:
-      Size: '2'
-    501-1000:
-      Size: '3'
-    1001-2000:
-      Size: '4'
 Resources:
   MasterMP:
     Type: AWS::CloudFormation::Stack
+    DependsOn: Infrastructure
     Condition: PerHostSupportedRegion
     Properties:
       TemplateURL:
         Fn::Sub:
-        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/marketplace/master-mp.template
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/rhel/master-rhel.template
         - QSS3Region:
             !If
             - GovCloudCondition
@@ -326,26 +177,15 @@ Resources:
             - s3
       Parameters:
         AWSIKeyPairName: !Ref AWSKeyPairName
-        AWSIVPC: !Ref AWSVPC
-        DSISubnetID: !Ref DeepSecuritySubnet
-        DBIRDSInstanceSize:
-          !FindInMap
-          - RDSInstanceSize
-          - !Ref AWS::Region
-          - !FindInMap
-            - DeploymentSize
-            - !Ref ProtectedInstances
-            - Size
-        DBIStorageAllocation:
-          !FindInMap
-          - RDSStorageSize
-          - !Ref ProtectedInstances
-          - Size
+        AWSIVPC: !GetAtt Infrastructure.Outputs.VPCID
+        DSISubnetID: !GetAtt Infrastructure.Outputs.PublicSubnet
+        DBIRDSInstanceSize: db.m4.large
+        DBIStorageAllocation: '10'
         DBPBackupDays: '5'
         DBPCreateDbInstance: 'Yes'
         DBICAdminName: dsmadmin
         DBICAdminPassword: !Ref DeepSecurityAdminPass
-        DBPEngine: PostgreSQL
+        DBPEngine: PostgresDocker
         DBPEndpoint: ''
         DBPName: dsm
         DSCAdminName: !Ref DeepSecurityAdminName
@@ -358,16 +198,25 @@ Resources:
           !FindInMap
           - DSMSIZE
           - !Ref AWS::Region
-          - !FindInMap
-            - DeploymentSize
-            - !Ref ProtectedInstances
-            - Size
-        DBISubnet1: !Ref DatabaseSubnet1
-        DBISubnet2: !Ref DatabaseSubnet2
-        DSIPLicense: PerHost
+          - '1'
+        DBISubnet1: !GetAtt Infrastructure.Outputs.PublicSubnet
+        DBISubnet2: !GetAtt Infrastructure.Outputs.PrivateSubnet2
         DBPMultiAZ: 'true'
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
+  Infrastructure:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL:
+        Fn::Sub:
+        - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/quickstart/Infrastructure.template
+        - QSS3Region:
+            !If
+            - GovCloudCondition
+            - s3-us-gov-west-1
+            - s3
+      Parameters:
+        EnableDNSHostNames: 'true'
 Conditions:
   PerHostSupportedRegion:
     !Not

--- a/templates/quickstart/trendmicro-deepsecurity-poc.template
+++ b/templates/quickstart/trendmicro-deepsecurity-poc.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.14: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.15: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ Oracle RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS
@@ -74,7 +74,7 @@ Parameters:
   DatabaseSubnet2:
     Description: >-
       Select a second private subnet for the RDS database.  Must be a private
-      subnet contained the in VPC chosen above.
+      subnet contained in the VPC chosen above.
     Type: 'AWS::EC2::Subnet::Id'
     ConstraintDescription: >-
       RDS Subnet Groups must be comprised of 2 subnets in seperate availability
@@ -82,7 +82,7 @@ Parameters:
   DeepSecuritySubnet:
     Description: >-
       Select an existing Subnet for Deep Security Manager. Must be a public
-      subnet contained the in VPC chosen above.
+      subnet contained in the VPC chosen above.
     Type: 'AWS::EC2::Subnet::Id'
     MinLength: '1'
     MaxLength: '255'

--- a/templates/quickstart/trendmicro-deepsecurity-rhel.template
+++ b/templates/quickstart/trendmicro-deepsecurity-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.14: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.15: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS
@@ -75,7 +75,7 @@ Parameters:
   DatabaseSubnet2:
     Description: >-
       Select a second private subnet for the RDS database.  Must be a private
-      subnet contained the in VPC chosen above.
+      subnet contained in the VPC chosen above.
     Type: 'AWS::EC2::Subnet::Id'
     ConstraintDescription: >-
       RDS Subnet Groups must be comprised of 2 subnets in seperate availability
@@ -83,7 +83,7 @@ Parameters:
   DeepSecuritySubnet:
     Description: >-
       Select an existing Subnet for Deep Security Manager. Must be a public
-      subnet contained the in VPC chosen above.
+      subnet contained in the VPC chosen above.
     Type: 'AWS::EC2::Subnet::Id'
     MinLength: '1'
     MaxLength: '255'

--- a/templates/quickstart/trendmicro-deepsecurity-tp.template
+++ b/templates/quickstart/trendmicro-deepsecurity-tp.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.14: Quick Start that deploys a new VPC with Trend Micro Deep Security
+  v5.15: Quick Start that deploys a new VPC with Trend Micro Deep Security
   **WARNING** This template uses images from the AWS Marketplace and an active
   subscription is required - Please see the Quick Start documentation for more
   details. You will be billed for the AWS resources used if you create a stack

--- a/templates/rhel/dsm-rhel.template
+++ b/templates/rhel/dsm-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.14: Deploys Deep Security Manager to AWS. This template is designed to be
+  v5.15: Deploys Deep Security Manager to AWS. This template is designed to be
   nested in a stack, and requires several passed parameters to launch.
   **WARNING** This template creates Amazon EC2 instances and related resources.
   You will be billed for the AWS resources used if you create a stack from this
@@ -131,13 +131,13 @@ Parameters:
   DSMSG:
     Type: 'AWS::EC2::SecurityGroup::Id'
   DBPEngine:
-    Default: Embedded
+    Default: PostgreSQL
     Type: String
     AllowedValues:
-      - Embedded
       - Oracle
       - SQL
       - PostgreSQL
+      - PostgresDocker
   DSISubnetID:
     Description: >-
       Existing Subnet for Deep Security Manager. Must be a public subnet
@@ -263,6 +263,8 @@ Mappings:
     Embedded:
       DbTypeString: Embedded
     PostgreSQL:
+      DbTypeString: PostgreSQL
+    PostgresDocker:
       DbTypeString: PostgreSQL
 Resources:
   DSMRole:
@@ -438,9 +440,9 @@ Resources:
                 https://files.trendmicro.com/products/deepsecurity/en/11.0/Agent-RedHat_EL6-11.0.0-211.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-RedHat_EL6-11.0.0-211.x86_64.zip:
+            /tmp/KernelSupport-RedHat_EL6-11.0.0-256.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-RedHat_EL6-11.0.0-211.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-RedHat_EL6-11.0.0-256.x86_64.zip
               owner: root
               mode: '000600'
             /tmp/Agent-RedHat_EL7-11.0.0-211.x86_64.zip:
@@ -448,9 +450,9 @@ Resources:
                 https://files.trendmicro.com/products/deepsecurity/en/11.0/Agent-RedHat_EL7-11.0.0-211.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-RedHat_EL7-11.0.0-211.x86_64.zip:
+            /tmp/KernelSupport-RedHat_EL7-11.0.0-249.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-RedHat_EL7-11.0.0-211.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-RedHat_EL7-11.0.0-249.x86_64.zip
               owner: root
               mode: '000600'
             /tmp/Agent-Ubuntu_16.04-11.0.0-211.x86_64.zip:
@@ -458,9 +460,9 @@ Resources:
                 https://files.trendmicro.com/products/deepsecurity/en/11.0/Agent-Ubuntu_16.04-11.0.0-211.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-Ubuntu_16.04-11.0.0-211.x86_64.zip:
+            /tmp/KernelSupport-Ubuntu_16.04-11.0.0-254.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-Ubuntu_16.04-11.0.0-211.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-Ubuntu_16.04-11.0.0-254.x86_64.zip
               owner: root
               mode: '000600'
             /tmp/Agent-Ubuntu_14.04-10.0.0-2094.x86_64.zip:
@@ -478,9 +480,9 @@ Resources:
                 https://files.trendmicro.com/products/deepsecurity/en/11.0/Agent-amzn1-11.0.0-211.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-amzn1-11.0.0-211.x86_64.zip:
+            /tmp/KernelSupport-amzn1-11.0.0-253.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-amzn1-11.0.0-211.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-amzn1-11.0.0-253.x86_64.zip
               owner: root
               mode: '000600'
             /tmp/Agent-amzn2-11.0.0-211.x86_64.zip:
@@ -488,9 +490,9 @@ Resources:
                 https://files.trendmicro.com/products/deepsecurity/en/11.0/Agent-amzn2-11.0.0-211.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-amzn2-11.0.0-211.x86_64.zip:
+            /tmp/KernelSupport-amzn2-11.0.0-252.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-amzn2-11.0.0-211.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.0/KernelSupport-amzn2-11.0.0-252.x86_64.zip
               owner: root
               mode: '000600'
             /tmp/Agent-Windows-11.0.0-223.x86_64.zip:
@@ -611,7 +613,7 @@ Resources:
               ignoreErrors: 'false'
             1-install-DSM:
               command: >-
-                cd /tmp; sh Manager-Linux-10.3.102.x64.sh -q -console -varfile
+                cd /tmp; sh Manager-Linux-11.0.221.x64.sh -q -console -varfile
                 /etc/cfn/dsmConfiguration.properties >> /tmp/dsmInstallLog
               ignoreErrors: 'false'
             2-fix-for-systemd:
@@ -915,18 +917,9 @@ Resources:
             - |+
 
 Conditions:
-  DBTypeIsOracle: !Equals 
-    - !Ref DBPEngine
-    - Oracle
-  DBTypeIsSQL: !Equals 
-    - !Ref DBPEngine
-    - SQL
-  DBTypeIsEmbedded: !Equals 
-    - !Ref DBPEngine
-    - Embedded
-  DBTypeIsPostgreSQL: !Equals 
-    - !Ref DBPEngine
-    - PostgreSQL
+  DBTypeIsSQL: !Equals
+      - !Ref DBPEngine
+      - SQL
   IsFirstNode: !Equals 
     - !Ref DSMPMNode
     - 'No'

--- a/templates/rhel/master-rhel.template
+++ b/templates/rhel/master-rhel.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.14: Trend Micro Deep Security AWS RHEL master template.'
+Description: 'v5.15: Trend Micro Deep Security AWS RHEL master template.'
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:
@@ -185,6 +185,7 @@ Parameters:
       - SQL
       - Oracle
       - PostgreSQL
+      - PostgresDocker
   DBPEndpoint:
     Type: String
     Description: >-
@@ -523,6 +524,7 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
+        AWSIKeyPairName: !Ref AWSIKeyPairName
         DBPName: !Ref DBPName
         DBIStorageAllocation: !Ref DBIStorageAllocation
         DBIRDSInstanceSize: !Ref DBIRDSInstanceSize


### PR DESCRIPTION
Added new demo template
- Creates VPC and subnet infrastructure
- Uses PosgreSQL on Docker instead of RDS
- Template Spins up in 15 minutes
- Launches RHEL templates to avoid marketplace subscription issues

Fixed 11.0 kernel support package links