### PR TITLE
Release/ds 11.2 missed updates

### DIFF
--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.16: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.17: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -265,53 +265,53 @@ Mappings:
       BYOL: ami-0e6e7d7edacbff83a
   DSMSIZE:
     us-east-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     us-east-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     us-west-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     us-west-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ca-central-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-south-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-northeast-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-southeast-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-southeast-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     ap-northeast-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     eu-central-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     eu-west-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     eu-west-2:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     eu-west-3:
-      PerHost: r4.xlarge
-      BYOL: r4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     sa-east-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
     us-gov-west-1:
-      PerHost: m4.xlarge
-      BYOL: m4.xlarge
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
   DSMDBMap:
     SQL:
       DbTypeString: Microsoft SQL Server

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.16: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.17: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:

--- a/templates/quickstart/Infrastructure.template
+++ b/templates/quickstart/Infrastructure.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.16: Template for testing the Quick Start, Creates the VPCs
+Description: 'v5.17: Template for testing the Quick Start, Creates the VPCs
   and subnets needed for deployment'
 Parameters:
   EnableDNSHostNames:

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.16: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.17: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ RDS instance  **WARNING** This template uses
   images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-demo.template
+++ b/templates/quickstart/trendmicro-deepsecurity-demo.template
@@ -82,85 +82,85 @@ Parameters:
 Mappings:
   DSMSIZE:
     us-east-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-west-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-west-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-west-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-central-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     sa-east-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-northeast-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-southeast-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-southeast-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-northeast-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-east-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ca-central-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-south-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-west-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-west-3:
-      '1': r4.large
-      '2': r4.large
-      '3': r4.xlarge
-      '4': r4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-gov-west-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
 Resources:
   MasterMP:
     Type: AWS::CloudFormation::Stack

--- a/templates/quickstart/trendmicro-deepsecurity-demo.template
+++ b/templates/quickstart/trendmicro-deepsecurity-demo.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'DEMO ONLY - v5.16: Demo of the Trend Micro Deep Security Quick Start.
+Description: 'DEMO ONLY - v5.17: Demo of the Trend Micro Deep Security Quick Start.
   This template creates the VPC infrastructure needed for the Quick Start and deploys an
   EC2 instance with Docker and PostgreSQL for the database. **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please

--- a/templates/quickstart/trendmicro-deepsecurity-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.16: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.17: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-poc.template
+++ b/templates/quickstart/trendmicro-deepsecurity-poc.template
@@ -139,33 +139,33 @@ Parameters:
 Mappings:
   DSMSIZE:
     us-east-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     us-west-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     us-west-2:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     eu-west-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     eu-central-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     sa-east-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     ap-northeast-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     ap-southeast-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     ap-southeast-2:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     ap-northeast-2:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     us-east-2:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     ca-central-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     ap-south-1:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
     eu-west-2:
-      MMS: m4.xlarge
+      MMS: m5.xlarge
   RDSStorageSize:
     1-100:
       Size: '75'

--- a/templates/quickstart/trendmicro-deepsecurity-poc.template
+++ b/templates/quickstart/trendmicro-deepsecurity-poc.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.16: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.17: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ Oracle RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-rhel.template
+++ b/templates/quickstart/trendmicro-deepsecurity-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.16: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.17: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-rhel.template
+++ b/templates/quickstart/trendmicro-deepsecurity-rhel.template
@@ -141,80 +141,80 @@ Parameters:
 Mappings:
   DSMSIZE:
     us-east-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-west-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-west-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-west-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-central-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     sa-east-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-northeast-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-southeast-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-southeast-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-northeast-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-east-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ca-central-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-south-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-west-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-gov-west-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
   RDSStorageSize:
     1-100:
       Size: '50'

--- a/templates/quickstart/trendmicro-deepsecurity-tp.template
+++ b/templates/quickstart/trendmicro-deepsecurity-tp.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.16: Quick Start that deploys a new VPC with Trend Micro Deep Security
+  v5.17: Quick Start that deploys a new VPC with Trend Micro Deep Security
   **WARNING** This template uses images from the AWS Marketplace and an active
   subscription is required - Please see the Quick Start documentation for more
   details. You will be billed for the AWS resources used if you create a stack

--- a/templates/quickstart/trendmicro-deepsecurity-tp.template
+++ b/templates/quickstart/trendmicro-deepsecurity-tp.template
@@ -97,75 +97,75 @@ Parameters:
 Mappings:
   DSMSIZE:
     us-east-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-west-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-west-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-west-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-central-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     sa-east-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-northeast-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-southeast-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-southeast-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-northeast-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     us-east-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ca-central-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     ap-south-1:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
     eu-west-2:
-      '1': m4.large
-      '2': m4.large
-      '3': m4.xlarge
-      '4': m4.xlarge
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
   RDSStorageSize:
     1-100:
       Size: '50'

--- a/templates/rhel/dsm-rhel.template
+++ b/templates/rhel/dsm-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.16: Deploys Deep Security Manager to AWS. This template is designed to be
+  v5.17: Deploys Deep Security Manager to AWS. This template is designed to be
   nested in a stack, and requires several passed parameters to launch.
   **WARNING** This template creates Amazon EC2 instances and related resources.
   You will be billed for the AWS resources used if you create a stack from this

--- a/templates/rhel/master-rhel.template
+++ b/templates/rhel/master-rhel.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.16: Trend Micro Deep Security AWS RHEL master template.'
+Description: 'v5.17: Trend Micro Deep Security AWS RHEL master template.'
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:


### PR DESCRIPTION
There were some updates that were missing from the previous PR.

- Updated missed templates to version 5.17
- Use m5 as DSM default instance type for other templates