### PR TITLE
typo fix in variable name

### DIFF
--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -440,7 +440,7 @@ Resources:
     Type: AWS::EC2::Instance
     Metadata:
       AWS::CloudFormation::Authentication:
-        S3AcccessCreds:
+        S3AccessCreds:
           type: S3
           roleName: !Ref DSMRole
           buckets: !Ref QSS3BucketName
@@ -575,7 +575,7 @@ Resources:
                     - s3
               owner: root
               mode: '000700'
-              authentication: S3AcccessCreds
+              authentication: S3AccessCreds
             /etc/cfn/kill-mp-web-installer.sh:
               source:
                 Fn::Sub:
@@ -587,7 +587,7 @@ Resources:
                     - s3
               owner: root
               mode: '000700'
-              authentication: S3AcccessCreds
+              authentication: S3AccessCreds
             /etc/cfn/add-aws-account-with-instance-role.sh:
               source:
                 Fn::Sub:
@@ -599,7 +599,7 @@ Resources:
                     - s3
               owner: root
               mode: '000700'
-              authentication: S3AcccessCreds
+              authentication: S3AccessCreds
           commands:
             5-check-service:
               command:
@@ -630,7 +630,7 @@ Resources:
                     - s3
               owner: root
               mode: '000755'
-              authentication: S3AcccessCreds
+              authentication: S3AccessCreds
           commands:
             1-create-db:
               command:
@@ -659,7 +659,7 @@ Resources:
                     - s3
               owner: root
               mode: '000700'
-              authentication: S3AcccessCreds
+              authentication: S3AccessCreds
             /etc/cfn/set-lb-settings.sh:
               source:
                 Fn::Sub:
@@ -671,7 +671,7 @@ Resources:
                     - s3
               owner: root
               mode: '000700'
-              authentication: S3AcccessCreds
+              authentication: S3AccessCreds
           commands:
             1-setup-elb-listener:
               command:
@@ -700,7 +700,7 @@ Resources:
                     - s3
               owner: root
               mode: '000700'
-              authentication: S3AcccessCreds
+              authentication: S3AccessCreds
           commands:
             1-reactivate-manager.sh:
               command:


### PR DESCRIPTION
This change was made into AWS QuickStart repository with following commits:

https://github.com/aws-quickstart/quickstart-trendmicro-deepsecurity/commit/0be30c5952c742c3f3d007fa3814cd54622e6b19
https://github.com/aws-quickstart/quickstart-trendmicro-deepsecurity/commit/eee3dd2ad65dbf66445c9ba23c8e3111c25bf959
Applying same change on deep-security/cloudformation