### PR TITLE
Updated templates to version 5.19

### DIFF
--- a/templates/common/db/ds-db-abstract.template
+++ b/templates/common/db/ds-db-abstract.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: This template is an abstraction layer for choosing PostgreSQL,
+Description: 'v5.19: This template is an abstraction layer for choosing PostgreSQL,
   Oracle or MSSQL when deploying Deep Security Manager. (qs-1ngr590i4)'
 Parameters:
   AWSIKeyPairName:

--- a/templates/common/db/ds-db-mssql-rds.template
+++ b/templates/common/db/ds-db-mssql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: This template deploys an MSSQL RDS Instance for Deep Security
+Description: 'v5.19: This template deploys an MSSQL RDS Instance for Deep Security
   Manager. (qs-1ngr590ij)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-oracle-rds.template
+++ b/templates/common/db/ds-db-oracle-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: This template deploys an Oracle RDS instance for Deep Security
+Description: 'v5.19: This template deploys an Oracle RDS instance for Deep Security
   Manager. (qs-1ngr590i9)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-postgresql-docker.template
+++ b/templates/common/db/ds-db-postgresql-docker.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
+Description: 'v5.19: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
   This template deploys PostgreSQL on Docker for Deep Security Manager.'
 Parameters:
   AWSIKeyPairName:

--- a/templates/common/db/ds-db-postgresql-rds.template
+++ b/templates/common/db/ds-db-postgresql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: This template deploys a PostgreSQL RDS instance for Deep Security
+Description: 'v5.19: This template deploys a PostgreSQL RDS instance for Deep Security
   Manager. (qs-1ngr590ie)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/dsm-elb.template
+++ b/templates/common/dsm-elb.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: Deploys Elastic Load Balancers and Security Groups for Deep Security
+Description: 'v5.19: Deploys Elastic Load Balancers and Security Groups for Deep Security
   (qs-1ngr590je). Manager.'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/ds-elb-sg.template
+++ b/templates/common/security-groups/ds-elb-sg.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: This template creates security groups for the ELB for Deep Security
+Description: 'v5.19: This template creates security groups for the ELB for Deep Security
   Manager. (qs-1ngr590io)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-security-group.template
+++ b/templates/common/security-groups/dsm-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: This template creates the security group to allow inbound communication
+Description: 'v5.19: This template creates the security group to allow inbound communication
   to Deep Security Manager. (qs-1ngr590iu)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-sg-ingress-rules.template
+++ b/templates/common/security-groups/dsm-sg-ingress-rules.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: This template creates the ingress rules for Deep Security Managers.
+Description: 'v5.19: This template creates the ingress rules for Deep Security Managers.
   (qs-1ngr590j4)'
 Parameters:
   DSMSG:

--- a/templates/common/security-groups/rds-security-group.template
+++ b/templates/common/security-groups/rds-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: This template creates the security group to allow communication
+Description: 'v5.19: This template creates the security group to allow communication
   from Deep Security Managers to their RDS Instance. (qs-1ngr590j9)'
 Parameters:
   AWSIVPC:

--- a/templates/common/sps.template
+++ b/templates/common/sps.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.18: Smart protection server template (qs-1ngr590jj).
+  v5.19: Smart protection server template (qs-1ngr590jj).
 Parameters:
   AWSIKeyPairName:
     Description: Existing key pair to use for connecting to your Smart Protection Server

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.19: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.19: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:

--- a/templates/quickstart/Infrastructure.template
+++ b/templates/quickstart/Infrastructure.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: Template for testing the Quick Start, Creates the VPCs
+Description: 'v5.19: Template for testing the Quick Start, Creates the VPCs
   and subnets needed for deployment'
 Parameters:
   EnableDNSHostNames:

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.18: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.19: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ RDS instance  **WARNING** This template uses
   images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS
@@ -203,11 +203,11 @@ Mappings:
       BYOL: m5.xlarge
     eu-west-2:
       BYOL: m5.xlarge
+    eu-west-3:
+      BYOL: m5.xlarge
     sa-east-1:
       BYOL: m5.xlarge
     us-gov-west-1:
-      BYOL: m5.xlarge
-    eu-west-3:
       BYOL: m5.xlarge
   RDSInstanceSize:
     us-east-1:

--- a/templates/quickstart/trendmicro-deepsecurity-demo.template
+++ b/templates/quickstart/trendmicro-deepsecurity-demo.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'DEMO ONLY - v5.18: Demo of the Trend Micro Deep Security Quick Start.
+Description: 'DEMO ONLY - v5.19: Demo of the Trend Micro Deep Security Quick Start.
   This template creates the VPC infrastructure needed for the Quick Start and deploys an
   EC2 instance with Docker and PostgreSQL for the database. **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please

--- a/templates/quickstart/trendmicro-deepsecurity-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.18: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.19: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-poc.template
+++ b/templates/quickstart/trendmicro-deepsecurity-poc.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.18: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.19: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ Oracle RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-rhel.template
+++ b/templates/quickstart/trendmicro-deepsecurity-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.18: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.19: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-tp.template
+++ b/templates/quickstart/trendmicro-deepsecurity-tp.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.18: Quick Start that deploys a new VPC with Trend Micro Deep Security
+  v5.19: Quick Start that deploys a new VPC with Trend Micro Deep Security
   **WARNING** This template uses images from the AWS Marketplace and an active
   subscription is required - Please see the Quick Start documentation for more
   details. You will be billed for the AWS resources used if you create a stack

--- a/templates/rhel/dsm-rhel.template
+++ b/templates/rhel/dsm-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.18: Deploys Deep Security Manager to AWS. This template is designed to be
+  v5.19: Deploys Deep Security Manager to AWS. This template is designed to be
   nested in a stack, and requires several passed parameters to launch.
   **WARNING** This template creates Amazon EC2 instances and related resources.
   You will be billed for the AWS resources used if you create a stack from this
@@ -208,35 +208,39 @@ Parameters:
 Mappings:
   AWSRegionArch2AMI:
     eu-central-1:
-      '64': ami-e4c63e8b
+      '64': ami-09de4a4c670389e4b
     sa-east-1:
-      '64': ami-7de77b11
+      '64': ami-05c1c16cac05a7c0b
     ap-northeast-1:
-      '64': ami-5de0433c
+      '64': ami-00b95502a4d51a07e
     ap-northeast-2:
-      '64': ami-6447930a
+      '64': ami-041b16ca28f036753
     ap-south-1:
-      '64': ami-7c9bef13
+      '64': ami-0963937a03c01ecd4
     eu-west-1:
-      '64': ami-02ace471
+      '64': ami-0202869bdd0fc8c75
     eu-west-2:
-      '64': ami-9c363cf8
+      '64': ami-0188c0c5eddd2d032
     ca-central-1:
-      '64': ami-9062d0f4
+      '64': ami-06ca3c0058d0275b3
     us-east-1:
-      '64': ami-b63769a1
+      '64': ami-000db10762d0c4c05
     us-east-2:
-      '64': ami-0932686c
+      '64': ami-094720ddca649952f
     us-west-1:
-      '64': ami-2cade64c
+      '64': ami-04642fc8fca1e8e67
     us-west-2:
-      '64': ami-6f68cf0f
+      '64': ami-0a7e1ebfee7a4570e
     ap-southeast-2:
-      '64': ami-39ac915a
+      '64': ami-036b423b657376f5b
     ap-southeast-1:
-      '64': ami-2c95344f
+      '64': ami-055c55112e25b1f1f
+    eu-west-3:
+      '64': ami-0c4224e392ec4e440
+    eu-north-1:
+      '64': ami-66f67f18
     us-gov-west-1:
-      '64': ami-299e2248
+      '64': ami-a1d349c0
   TrendRegionMap:
     us-east-1:
       regionkey: amazon.cloud.region.key.1
@@ -438,34 +442,34 @@ Resources:
                 https://files.trendmicro.com/products/deepsecurity/en/11.3/Manager-Linux-11.3.184.x64.sh
               owner: root
               mode: '000700'
-            /tmp/Agent-RedHat_EL6-11.3.0-168.x86_64.zip:
+            /tmp/Agent-RedHat_EL6-11.3.0-235.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-RedHat_EL6-11.3.0-168.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-RedHat_EL6-11.3.0-235.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-RedHat_EL6-11.3.0-168.x86_64.zip:
+            /tmp/KernelSupport-RedHat_EL6-11.3.0-239.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-RedHat_EL6-11.3.0-168.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-RedHat_EL6-11.3.0-239.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/Agent-RedHat_EL7-11.3.0-168.x86_64.zip:
+            /tmp/Agent-RedHat_EL7-11.3.0-235.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-RedHat_EL7-11.3.0-168.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-RedHat_EL7-11.3.0-235.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-RedHat_EL7-11.3.0-168.x86_64.zip:
+            /tmp/KernelSupport-RedHat_EL7-11.3.0-272.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-RedHat_EL7-11.3.0-168.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-RedHat_EL7-11.3.0-272.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/Agent-Ubuntu_16.04-11.3.0-168.x86_64.zip:
+            /tmp/Agent-Ubuntu_16.04-11.3.0-235.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-Ubuntu_16.04-11.3.0-168.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-Ubuntu_16.04-11.3.0-235.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-Ubuntu_16.04-11.3.0-168.x86_64.zip:
+            /tmp/KernelSupport-Ubuntu_16.04-11.3.0-281.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-Ubuntu_16.04-11.3.0-168.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-Ubuntu_16.04-11.3.0-281.x86_64.zip
               owner: root
               mode: '000600'
             /tmp/Agent-Ubuntu_14.04-10.0.0-2094.x86_64.zip:
@@ -478,29 +482,29 @@ Resources:
                 http://files.trendmicro.com/products/deepsecurity/en/10.0/KernelSupport-Ubuntu_14.04-10.0.0-2114.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/Agent-amzn1-11.3.0-168.x86_64.zip:
+            /tmp/Agent-amzn2-11.3.0-235.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-amzn1-11.3.0-168.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-amzn2-11.3.0-235.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-amzn1-11.3.0-168.x86_64.zip:
+            /tmp/KernelSupport-amzn1-11.3.0-267.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-amzn1-11.3.0-168.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-amzn1-11.3.0-267.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/Agent-amzn2-11.3.0-168.x86_64.zip:
+            /tmp/Agent-amzn2-11.3.0-235.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-amzn2-11.3.0-168.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-amzn2-11.3.0-235.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/KernelSupport-amzn2-11.3.0-168.x86_64.zip:
+            /tmp/KernelSupport-amzn2-11.3.0-273.x86_64.zip:
               source: >-
-                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-amzn2-11.3.0-168.x86_64.zip
+                http://files.trendmicro.com/products/deepsecurity/en/11.3/KernelSupport-amzn2-11.3.0-273.x86_64.zip
               owner: root
               mode: '000600'
-            /tmp/Agent-Windows-11.3.0-169.x86_64.zip:
+            /tmp/Agent-Windows-11.3.0-235.x86_64.zip:
               source: >-
-                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-Windows-11.3.0-169.x86_64.zip
+                https://files.trendmicro.com/products/deepsecurity/en/11.3/Agent-Windows-11.3.0-235.x86_64.zip
               owner: root
               mode: '000600'
             /etc/cfn/dsmConfiguration.properties:
@@ -616,7 +620,7 @@ Resources:
               ignoreErrors: 'false'
             1-install-DSM:
               command: >-
-                cd /tmp; sh Manager-Linux-11.2.225.x64.sh -q -console -varfile
+                cd /tmp; sh Manager-Linux-11.3.184.x64.sh -q -console -varfile
                 /etc/cfn/dsmConfiguration.properties >> /tmp/dsmInstallLog
               ignoreErrors: 'false'
             2-fix-for-systemd:

--- a/templates/rhel/master-rhel.template
+++ b/templates/rhel/master-rhel.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.18: Trend Micro Deep Security AWS RHEL master template.'
+Description: 'v5.19: Trend Micro Deep Security AWS RHEL master template.'
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:


### PR DESCRIPTION
- Updated Red Hat AMI to version 7.6 to get ENA networking support so the templates can use m5 instances.
- Updated Agent and kernel support packages as some of the older links are no longer available. 