### PR TITLE
Updated templates to version 5.22

### DIFF
--- a/templates/common/db/ds-db-abstract.template
+++ b/templates/common/db/ds-db-abstract.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: This template is an abstraction layer for choosing PostgreSQL,
+Description: 'v5.22: This template is an abstraction layer for choosing PostgreSQL,
   Oracle or MSSQL when deploying Deep Security Manager. (qs-1ngr590i4)'
 Parameters:
   AWSIKeyPairName:

--- a/templates/common/db/ds-db-mssql-rds.template
+++ b/templates/common/db/ds-db-mssql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: This template deploys an MSSQL RDS Instance for Deep Security
+Description: 'v5.22: This template deploys an MSSQL RDS Instance for Deep Security
   Manager. (qs-1ngr590ij)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-oracle-rds.template
+++ b/templates/common/db/ds-db-oracle-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: This template deploys an Oracle RDS instance for Deep Security
+Description: 'v5.22: This template deploys an Oracle RDS instance for Deep Security
   Manager. (qs-1ngr590i9)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-postgresql-docker.template
+++ b/templates/common/db/ds-db-postgresql-docker.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
+Description: 'v5.22: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
   This template deploys PostgreSQL on Docker for Deep Security Manager.'
 Parameters:
   AWSIKeyPairName:

--- a/templates/common/db/ds-db-postgresql-rds.template
+++ b/templates/common/db/ds-db-postgresql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: This template deploys a PostgreSQL RDS instance for Deep Security
+Description: 'v5.22: This template deploys a PostgreSQL RDS instance for Deep Security
   Manager. (qs-1ngr590ie)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/dsm-elb.template
+++ b/templates/common/dsm-elb.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: Deploys Elastic Load Balancers and Security Groups for Deep Security
+Description: 'v5.22: Deploys Elastic Load Balancers and Security Groups for Deep Security
   (qs-1ngr590je). Manager.'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/ds-elb-sg.template
+++ b/templates/common/security-groups/ds-elb-sg.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: This template creates security groups for the ELB for Deep Security
+Description: 'v5.22: This template creates security groups for the ELB for Deep Security
   Manager. (qs-1ngr590io)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-security-group.template
+++ b/templates/common/security-groups/dsm-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: This template creates the security group to allow inbound communication
+Description: 'v5.22: This template creates the security group to allow inbound communication
   to Deep Security Manager. (qs-1ngr590iu)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-sg-ingress-rules.template
+++ b/templates/common/security-groups/dsm-sg-ingress-rules.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: This template creates the ingress rules for Deep Security Managers.
+Description: 'v5.22: This template creates the ingress rules for Deep Security Managers.
   (qs-1ngr590j4)'
 Parameters:
   DSMSG:

--- a/templates/common/security-groups/rds-security-group.template
+++ b/templates/common/security-groups/rds-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: This template creates the security group to allow communication
+Description: 'v5.22: This template creates the security group to allow communication
   from Deep Security Managers to their RDS Instance. (qs-1ngr590j9)'
 Parameters:
   AWSIVPC:

--- a/templates/common/sps.template
+++ b/templates/common/sps.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.21: Smart protection server template (qs-1ngr590jj).
+  v5.22: Smart protection server template (qs-1ngr590jj).
 Parameters:
   AWSIKeyPairName:
     Description: Existing key pair to use for connecting to your Smart Protection Server

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.22: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'
@@ -139,7 +139,6 @@ Parameters:
     - Oracle
     - SQL
     - PostgreSQL
-    - PostgresDocker
   DSISubnetID:
     Description: Existing Subnet for Deep Security Manager. Must be a public subnet
       contained the in VPC chosen above.
@@ -322,8 +321,6 @@ Mappings:
     Embedded:
       DbTypeString: Embedded
     PostgreSQL:
-      DbTypeString: PostgreSQL
-    PostgresDocker:
       DbTypeString: PostgreSQL
 Resources:
   DSMRole:

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.22: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:
@@ -188,7 +188,6 @@ Parameters:
     - SQL
     - Oracle
     - PostgreSQL
-    - PostgresDocker
   DBPEndpoint:
     Type: String
     Description: If you have an existing oracle instance, enter the endpoint address

--- a/templates/quickstart/Infrastructure.template
+++ b/templates/quickstart/Infrastructure.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: Template for testing the Quick Start, Creates the VPCs
+Description: 'v5.22: Template for testing the Quick Start, Creates the VPCs
   and subnets needed for deployment'
 Parameters:
   EnableDNSHostNames:

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.21: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.22: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ RDS instance  **WARNING** This template uses
   images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-demo.template
+++ b/templates/quickstart/trendmicro-deepsecurity-demo.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'DEMO ONLY - v5.21: Demo of the Trend Micro Deep Security Quick Start.
+Description: 'DEMO ONLY - v5.22: Demo of the Trend Micro Deep Security Quick Start.
   This template creates the VPC infrastructure needed for the Quick Start and deploys an
   EC2 instance with Docker and PostgreSQL for the database. **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please

--- a/templates/quickstart/trendmicro-deepsecurity-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.21: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.22: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-poc.template
+++ b/templates/quickstart/trendmicro-deepsecurity-poc.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.21: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.22: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ Oracle RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-rhel.template
+++ b/templates/quickstart/trendmicro-deepsecurity-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.21: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.22: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-tp.template
+++ b/templates/quickstart/trendmicro-deepsecurity-tp.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.21: Quick Start that deploys a new VPC with Trend Micro Deep Security
+  v5.22: Quick Start that deploys a new VPC with Trend Micro Deep Security
   **WARNING** This template uses images from the AWS Marketplace and an active
   subscription is required - Please see the Quick Start documentation for more
   details. You will be billed for the AWS resources used if you create a stack

--- a/templates/rhel/dsm-rhel.template
+++ b/templates/rhel/dsm-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.21: Deploys Deep Security Manager to AWS. This template is designed to be
+  v5.22: Deploys Deep Security Manager to AWS. This template is designed to be
   nested in a stack, and requires several passed parameters to launch.
   **WARNING** This template creates Amazon EC2 instances and related resources.
   You will be billed for the AWS resources used if you create a stack from this

--- a/templates/rhel/master-rhel.template
+++ b/templates/rhel/master-rhel.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.21: Trend Micro Deep Security AWS RHEL master template.'
+Description: 'v5.22: Trend Micro Deep Security AWS RHEL master template.'
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:


### PR DESCRIPTION
The PostgreDocker option is a PoC and demo database configuration.  This update removes it from the master quick start templates.