### PR TITLE
Update templates to version 5.29

### DIFF
--- a/templates/common/db/ds-db-abstract.template
+++ b/templates/common/db/ds-db-abstract.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: This template is an abstraction layer for choosing PostgreSQL,
+Description: 'v5.29: This template is an abstraction layer for choosing PostgreSQL,
   Oracle or MSSQL when deploying Deep Security Manager. (qs-1ngr590i4)'
 Parameters:
   AWSIKeyPairName:
@@ -246,9 +246,13 @@ Conditions:
     - !Ref DBPEngine
     - PostgresDocker
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DSDBEndpoint:
     Value:

--- a/templates/common/db/ds-db-mssql-rds.template
+++ b/templates/common/db/ds-db-mssql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: This template deploys an MSSQL RDS Instance for Deep Security
+Description: 'v5.29: This template deploys an MSSQL RDS Instance for Deep Security
   Manager. (qs-1ngr590ij)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-oracle-rds.template
+++ b/templates/common/db/ds-db-oracle-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: This template deploys an Oracle RDS instance for Deep Security
+Description: 'v5.29: This template deploys an Oracle RDS instance for Deep Security
   Manager. (qs-1ngr590i9)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-postgresql-docker.template
+++ b/templates/common/db/ds-db-postgresql-docker.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
+Description: 'v5.29: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
   This template deploys PostgreSQL on Docker for Deep Security Manager.'
 Parameters:
   AWSIKeyPairName:

--- a/templates/common/db/ds-db-postgresql-rds.template
+++ b/templates/common/db/ds-db-postgresql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: This template deploys a PostgreSQL RDS instance for Deep Security
+Description: 'v5.29: This template deploys a PostgreSQL RDS instance for Deep Security
   Manager. (qs-1ngr590ie)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/dsm-elb.template
+++ b/templates/common/dsm-elb.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: Deploys Elastic Load Balancers and Security Groups for Deep Security
+Description: 'v5.29: Deploys Elastic Load Balancers and Security Groups for Deep Security
   (qs-1ngr590je). Manager.'
 Parameters:
   AWSIVPC:
@@ -115,9 +115,13 @@ Conditions:
     - !Ref DSELBPosture
     - Internet-facing
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   ELBFQDN:
     Value: !GetAtt DSMELB.DNSName

--- a/templates/common/security-groups/ds-elb-sg.template
+++ b/templates/common/security-groups/ds-elb-sg.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: This template creates security groups for the ELB for Deep Security
+Description: 'v5.29: This template creates security groups for the ELB for Deep Security
   Manager. (qs-1ngr590io)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-security-group.template
+++ b/templates/common/security-groups/dsm-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: This template creates the security group to allow inbound communication
+Description: 'v5.29: This template creates the security group to allow inbound communication
   to Deep Security Manager. (qs-1ngr590iu)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-sg-ingress-rules.template
+++ b/templates/common/security-groups/dsm-sg-ingress-rules.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: This template creates the ingress rules for Deep Security Managers.
+Description: 'v5.29: This template creates the ingress rules for Deep Security Managers.
   (qs-1ngr590j4)'
 Parameters:
   DSMSG:

--- a/templates/common/security-groups/rds-security-group.template
+++ b/templates/common/security-groups/rds-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: This template creates the security group to allow communication
+Description: 'v5.29: This template creates the security group to allow communication
   from Deep Security Managers to their RDS Instance. (qs-1ngr590j9)'
 Parameters:
   AWSIVPC:

--- a/templates/common/sps.template
+++ b/templates/common/sps.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.28: Smart protection server template (qs-1ngr590jj).
+  v5.29: Smart protection server template (qs-1ngr590jj).
 Parameters:
   AWSIKeyPairName:
     Description: Existing key pair to use for connecting to your Smart Protection Server

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.29: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'
@@ -65,9 +65,6 @@ Parameters:
     Type: String
     Default: m5.large
     AllowedValues:
-    - m3.large
-    - m3.xlarge
-    - m3.2xlarge
     - m4.large
     - m4.xlarge
     - m4.2xlarge
@@ -217,59 +214,62 @@ Parameters:
 Mappings:
   DSMAMI:
     ap-northeast-1:
-      PerHost: ami-06cd75cb051f71d9f
-      BYOL: ami-02e5734c2fb7f37f8
+      PerHost: ami-0a06cf345bcb94961
+      BYOL: ami-0e53022cc3ac5c242
     ap-northeast-2:
-      PerHost: ami-0d86dca5a53ff8d19
-      BYOL: ami-0f20268e4f142d49e
+      PerHost: ami-0f7a35c86a53680e5
+      BYOL: ami-04c21917bf067b5ff
     ap-south-1:
-      PerHost: ami-06c987efeef895cc0
-      BYOL: ami-0eda19c0cfdba7cdd
+      PerHost: ami-0216ff71932ff6b33
+      BYOL: ami-0419a7417af6c2cbf
     ap-southeast-1:
-      PerHost: ami-05546ef89c6256e4b
-      BYOL: ami-006fb0cc807d72ea7
+      PerHost: ami-0c779ab4e4359b688
+      BYOL: ami-07c81469219bf580b
     ap-southeast-2:
-      PerHost: ami-020770dcc2c5b8809
-      BYOL: ami-027db5ddf99b4599d
+      PerHost: ami-0b83dd8a4b5e4b5fd
+      BYOL: ami-0b7f7e6e4a354673c
     ca-central-1:
-      PerHost: ami-059129414fde09773
-      BYOL: ami-05afd521bed4ae0f7
+      PerHost: ami-07957e2fbd212f31c
+      BYOL: ami-03fabca24ef781d64
     eu-north-1:
-      PerHost: ami-3dc74c43
-      BYOL: ami-b3c74ccd
+      PerHost: ami-08e2794b372e62f41
+      BYOL: ami-0977ab0d8999b35ed
     eu-central-1:
-      PerHost: ami-038ad3bb0e9b13f63
-      BYOL: ami-04baa5ffb19b66507
+      PerHost: ami-018fd4fa97cade33a
+      BYOL: ami-01ece8b2af967cc0c
     eu-west-1:
-      PerHost: ami-0a47d28ceb1738009
-      BYOL: ami-0610d08c8d40ce2be
+      PerHost: ami-02815a1b94c22b6aa
+      BYOL: ami-0af87f0b7b472fc17
     eu-west-2:
-      PerHost: ami-0907a21ec2337f236
-      BYOL: ami-03a6be1c893edc7c5
+      PerHost: ami-01a379e24fbac9b5c
+      BYOL: ami-0911c92592519b753
     eu-west-3:
-      PerHost: ami-0422e471deaeb7bc6
-      BYOL: ami-02c2db50fe555fe98
+      PerHost: ami-0d2f1c865b1c01ade
+      BYOL: ami-0c375c6348c82d9c4
     sa-east-1:
-      PerHost: ami-0d3b777bc0ace4905
-      BYOL: ami-00831e5c63dc42d79
+      PerHost: ami-0e916f52198223063
+      BYOL: ami-00574b331fb4c0fad
     us-east-1:
-      PerHost: ami-0df091154c4066ff3
-      BYOL: ami-096cb89b385ff0876
+      PerHost: ami-086d874dcc2f96d24
+      BYOL: ami-0497d765b3e52acb8
     us-east-2:
-      PerHost: ami-0cd626ae72bd0bd51
-      BYOL: ami-0b0f40f6d446e8ddf
+      PerHost: ami-0f3df7a345c29b0a4
+      BYOL: ami-0487f509e69b4b3b0
     us-gov-west-1:
-      PerHost: ami-6a8cc90b
-      BYOL: ami-7788cd16
+      PerHost: ami-021a3163
+      BYOL: ami-05072c64
     us-west-1:
-      PerHost: ami-02ccc57d7418b28c6
-      BYOL: ami-0041a7cbd48160980
+      PerHost: ami-05dc2cd32e543bc7a
+      BYOL: ami-0461e8c93ed4d5e36
     us-west-2:
-      PerHost: ami-0a839d555bfb4e7b2
-      BYOL: ami-0aee1d974524d29ba
+      PerHost: ami-09280839c9d4f7542
+      BYOL: ami-0806a4a708e31ab92
     me-south-1 :
-      PerHost: ami-05727e9494c923314
-      BYOL: ami-042276eca86e21cdc
+      PerHost: ami-067ba0651799cfa01
+      BYOL: ami-0e87f839421ad9a0d
+    us-gov-east-1:
+      PerHost: ami-a519f4d4
+      BYOL: ami-0915f878
   DSMSIZE:
     us-east-1:
       PerHost: m5.xlarge
@@ -323,6 +323,9 @@ Mappings:
       PerHost: m5.xlarge
       BYOL: m5.xlarge
     me-south-1:
+      PerHost: m5.xlarge
+      BYOL: m5.xlarge
+    us-gov-east-1:
       PerHost: m5.xlarge
       BYOL: m5.xlarge
   DSMDBMap:
@@ -397,7 +400,7 @@ Resources:
                 !Join
                 - ''
                 - - !If
-                    - RegionIsUsGovWest1
+                    - GovCloudCondition
                     - 'arn:aws-us-gov:elasticloadbalancing:'
                     - 'arn:aws:elasticloadbalancing:'
                   - !Ref AWS::Region
@@ -413,7 +416,7 @@ Resources:
                 !Join
                 - ''
                 - - !If
-                    - RegionIsUsGovWest1
+                    - GovCloudCondition
                     - 'arn:aws-us-gov:iam::'
                     - 'arn:aws:iam::'
                   - !Ref AWS::AccountId
@@ -867,19 +870,19 @@ Conditions:
     !Equals
     - !Ref DSCLicenseType
     - Network
-  RegionIsUsGovWest1:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
   UseProxy:
     !Not
     - !Equals
       - !Ref DSProxyUrl
       - ''
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DSMFQDN:
     Value: !GetAtt DSM.PublicDnsName

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.29: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:
@@ -259,11 +259,8 @@ Parameters:
     Description: Amazon EC2 instance type for BYOL Deep Security Manager Node Instances
       (ignored for other license types)
     Type: String
-    Default: m3.xlarge
+    Default: m5.xlarge
     AllowedValues:
-    - m3.large
-    - m3.xlarge
-    - m3.2xlarge
     - m4.large
     - m4.xlarge
     - m4.2xlarge
@@ -665,9 +662,13 @@ Conditions:
     - !Ref DSELBPosture
     - Internet-facing
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DeepSecurityConsole:
     Value:

--- a/templates/quickstart/Infrastructure.template
+++ b/templates/quickstart/Infrastructure.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: Template for testing the Quick Start, Creates the VPCs
+Description: 'v5.29: Template for testing the Quick Start, Creates the VPCs
   and subnets needed for deployment'
 Parameters:
   EnableDNSHostNames:

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.28: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.29: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ RDS instance  **WARNING** This template uses
   images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS
@@ -213,6 +213,8 @@ Mappings:
       BYOL: m5.xlarge
     me-south-1:
       BYOL: m5.xlarge
+    us-gov-east-1:
+      BYOL: m5.xlarge
   RDSInstanceSize:
     us-east-1:
       Oracle: db.m5.xlarge
@@ -286,6 +288,10 @@ Mappings:
       Oracle: db.m5.xlarge
       MSSQL: db.m5.xlarge
       PostgreSQL: db.m5.xlarge
+    us-gov-east-1:
+      Oracle: db.r4.xlarge
+      MSSQL: db.r4.xlarge
+      PostgreSQL: db.r4.xlarge
   RDSMultiAZ:
     us-east-1:
       Oracle: 'true'
@@ -359,6 +365,10 @@ Mappings:
       Oracle: 'true'
       MSSQL: 'true'
       PostgreSQL: 'true'
+    us-gov-east-1:
+      Oracle: 'true'
+      MSSQL: 'true'
+      PostgreSQL: 'true'
 Resources:
   MasterMP:
     Type: AWS::CloudFormation::Stack
@@ -427,9 +437,13 @@ Conditions:
     - !Ref DatabaseEngine
     - MSSQL
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DeepSecurityConsole:
     Value: !GetAtt MasterMP.Outputs.DeepSecurityConsole

--- a/templates/quickstart/trendmicro-deepsecurity-demo.template
+++ b/templates/quickstart/trendmicro-deepsecurity-demo.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'DEMO ONLY - v5.28: Demo of the Trend Micro Deep Security Quick Start.
+Description: 'DEMO ONLY - v5.29: Demo of the Trend Micro Deep Security Quick Start.
   This template creates the VPC infrastructure needed for the Quick Start and deploys an
   EC2 instance with Docker and PostgreSQL for the database. **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
@@ -171,6 +171,11 @@ Mappings:
       '2': m5.large
       '3': m5.xlarge
       '4': m5.xlarge
+    us-gov-east-1:
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
 Resources:
   MasterMP:
     Type: AWS::CloudFormation::Stack
@@ -234,9 +239,13 @@ Conditions:
       - !Ref AWS::Region
       - match-all-regions
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DeepSecurityConsole:
     Value: !GetAtt MasterMP.Outputs.DeepSecurityConsole

--- a/templates/quickstart/trendmicro-deepsecurity-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.28: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.29: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS
@@ -222,6 +222,11 @@ Mappings:
       '2': m5.large
       '3': m5.xlarge
       '4': m5.xlarge
+    us-gov-east-1:
+      '1': m5.large
+      '2': m5.large
+      '3': m5.xlarge
+      '4': m5.xlarge
   RDSStorageSize:
     1-100:
       Size: '50'
@@ -322,6 +327,11 @@ Mappings:
       '2': db.m5.large
       '3': db.m5.xlarge
       '4': db.m5.xlarge
+    us-gov-east-1:
+      '1': db.r4.large
+      '2': db.r4.large
+      '3': db.r4.xlarge
+      '4': db.r4.xlarge
   DeploymentSize:
     1-100:
       Size: '1'
@@ -395,9 +405,13 @@ Conditions:
       - !Ref AWS::Region
       - match-all-regions
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DeepSecurityConsole:
     Value: !GetAtt MasterMP.Outputs.DeepSecurityConsole

--- a/templates/quickstart/trendmicro-deepsecurity-rhel.template
+++ b/templates/quickstart/trendmicro-deepsecurity-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.28: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.29: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS
@@ -372,9 +372,13 @@ Resources:
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
 Conditions:
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DeepSecurityConsole:
     Value: !GetAtt 

--- a/templates/rhel/dsm-rhel.template
+++ b/templates/rhel/dsm-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.28: Deploys Deep Security Manager to AWS. This template is designed to be
+  v5.29: Deploys Deep Security Manager to AWS. This template is designed to be
   nested in a stack, and requires several passed parameters to launch.
   **WARNING** This template creates Amazon EC2 instances and related resources.
   You will be billed for the AWS resources used if you create a stack from this
@@ -72,9 +72,6 @@ Parameters:
     Type: String
     Default: m4.large
     AllowedValues:
-      - m3.large
-      - m3.xlarge
-      - m3.2xlarge
       - m4.large
       - m4.xlarge
       - m4.2xlarge
@@ -316,7 +313,7 @@ Resources:
                   Resource: !Join 
                     - ''
                     - - !If 
-                        - RegionIsUsGovWest1
+                        - GovCloudCondition
                         - 'arn:aws-us-gov:elasticloadbalancing:'
                         - 'arn:aws:elasticloadbalancing:'
                       - !Ref 'AWS::Region'
@@ -331,7 +328,7 @@ Resources:
                   Resource: !Join 
                     - ''
                     - - !If 
-                        - RegionIsUsGovWest1
+                        - GovCloudCondition
                         - 'arn:aws-us-gov:iam::'
                         - 'arn:aws:iam::'
                       - !Ref 'AWS::AccountId'
@@ -959,17 +956,18 @@ Conditions:
   InternetFacingELB: !Equals 
     - !Ref DSELBPosture
     - Internet-facing
-  RegionIsUsGovWest1: !Equals 
-    - !Ref 'AWS::Region'
-    - us-gov-west-1
   UseProxy: !Not 
     - !Equals 
       - !Ref DSProxyUrl
       - ''
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DSMFQDN:
     Value: !GetAtt 

--- a/templates/rhel/master-rhel.template
+++ b/templates/rhel/master-rhel.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.28: Trend Micro Deep Security AWS RHEL master template.'
+Description: 'v5.29: Trend Micro Deep Security AWS RHEL master template.'
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:
@@ -261,11 +261,8 @@ Parameters:
   DSIPInstanceType:
     Description: Amazon EC2 instance type for the Deep Security Manager Node Instances
     Type: String
-    Default: m3.xlarge
+    Default: m5.xlarge
     AllowedValues:
-      - m3.large
-      - m3.xlarge
-      - m3.2xlarge
       - m4.large
       - m4.xlarge
       - m4.2xlarge
@@ -665,9 +662,13 @@ Conditions:
     - !Ref DSELBPosture
     - Internet-facing
   GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+    !Or 
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-west-1
+    - !Equals 
+      - !Ref AWS::Region
+      - us-gov-east-1
 Outputs:
   DeepSecurityConsole:
     Value: !Join 


### PR DESCRIPTION
- Updated the DSM to version 12.5.732
- Added support for the us-gov-east-1 region
- Changed the default instance size to M5