### PR TITLE
Updated templates to version 5.32

### DIFF
--- a/templates/common/db/ds-db-abstract.template
+++ b/templates/common/db/ds-db-abstract.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: This template is an abstraction layer for choosing PostgreSQL,
+Description: 'v5.32: This template is an abstraction layer for choosing PostgreSQL,
   Oracle or MSSQL when deploying Deep Security Manager. (qs-1ngr590i4)'
 Parameters:
   AWSIKeyPairName:

--- a/templates/common/db/ds-db-mssql-rds.template
+++ b/templates/common/db/ds-db-mssql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: This template deploys an MSSQL RDS Instance for Deep Security
+Description: 'v5.32: This template deploys an MSSQL RDS Instance for Deep Security
   Manager. (qs-1ngr590ij)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/db/ds-db-oracle-rds.template
+++ b/templates/common/db/ds-db-oracle-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: This template deploys an Oracle RDS instance for Deep Security
+Description: 'v5.32: This template deploys an Oracle RDS instance for Deep Security
   Manager. (qs-1ngr590i9)'
 Parameters:
   DBIRDSInstanceSize:
@@ -8,25 +8,27 @@ Parameters:
     Description: Trend Micro Deep Security Database instance class
     Type: String
     AllowedValues:
-    - db.m5.medium
     - db.m5.large
     - db.m5.xlarge
     - db.m5.2xlarge
+    - db.m5.4xlarge
     - db.m4.large
     - db.m4.xlarge
     - db.m4.2xlarge
     - db.m4.4xlarge
-    - db.m3.medium
-    - db.m3.large
-    - db.m3.xlarge
-    - db.m3.2xlarge
-    - db.r3.large
-    - db.r3.xlarge
-    - db.r3.2xlarge
-    - db.r3.4xlarge
-    - db.r3.8xlarge
     - db.r4.large
     - db.r4.xlarge
+    - db.r4.2xlarge
+    - db.r4.4xlarge
+    - db.r5.large
+    - db.r5.xlarge
+    - db.r5.2xlarge
+    - db.r5.4xlarge
+    - db.t3.small
+    - db.t3.medium
+    - db.t3.large
+    - db.t3.xlarge
+    - db.t3.2xlarge
     ConstraintDescription: must select a valid database instance type.
   DBIStorageAllocation:
     Default: 10
@@ -94,12 +96,8 @@ Resources:
       DBName: !Ref DBPName
       AllocatedStorage: !Ref DBIStorageAllocation
       DBInstanceClass: !Ref DBIRDSInstanceSize
-      Engine:
-        !If
-        - RegionIsUsGovCloud
-        - oracle-se1
-        - oracle-se2
-      EngineVersion: 12.1.0.2.v17
+      Engine: oracle-se2
+      EngineVersion: 19.0.0.0.ru-2020-04.rur-2020-04.r1
       MasterUsername: !Ref DBICAdminName
       MasterUserPassword: !Ref DBICAdminPassword
       VPCSecurityGroups:
@@ -113,10 +111,6 @@ Resources:
       - Key: Application
         Value: Deep Security Manager
 Conditions:
-  RegionIsUsGovCloud:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
   MultiAZ:
     !Equals
     - !Ref MultiAZ

--- a/templates/common/db/ds-db-postgresql-docker.template
+++ b/templates/common/db/ds-db-postgresql-docker.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
+Description: 'v5.32: ONLY FOR DEMO, NOT A SUPPORTED DEPLOYMENT OPTION.
   This template deploys PostgreSQL on Docker for Deep Security Manager.'
 Parameters:
   AWSIKeyPairName:

--- a/templates/common/db/ds-db-postgresql-rds.template
+++ b/templates/common/db/ds-db-postgresql-rds.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: This template deploys a PostgreSQL RDS instance for Deep Security
+Description: 'v5.32: This template deploys a PostgreSQL RDS instance for Deep Security
   Manager. (qs-1ngr590ie)'
 Parameters:
   DBIRDSInstanceSize:

--- a/templates/common/dsm-elb.template
+++ b/templates/common/dsm-elb.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: Deploys Elastic Load Balancers and Security Groups for Deep Security
+Description: 'v5.32: Deploys Elastic Load Balancers and Security Groups for Deep Security
   (qs-1ngr590je). Manager.'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/ds-elb-sg.template
+++ b/templates/common/security-groups/ds-elb-sg.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: This template creates security groups for the ELB for Deep Security
+Description: 'v5.32: This template creates security groups for the ELB for Deep Security
   Manager. (qs-1ngr590io)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-security-group.template
+++ b/templates/common/security-groups/dsm-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: This template creates the security group to allow inbound communication
+Description: 'v5.32: This template creates the security group to allow inbound communication
   to Deep Security Manager. (qs-1ngr590iu)'
 Parameters:
   AWSIVPC:

--- a/templates/common/security-groups/dsm-sg-ingress-rules.template
+++ b/templates/common/security-groups/dsm-sg-ingress-rules.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: This template creates the ingress rules for Deep Security Managers.
+Description: 'v5.32: This template creates the ingress rules for Deep Security Managers.
   (qs-1ngr590j4)'
 Parameters:
   DSMSG:

--- a/templates/common/security-groups/rds-security-group.template
+++ b/templates/common/security-groups/rds-security-group.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: This template creates the security group to allow communication
+Description: 'v5.32: This template creates the security group to allow communication
   from Deep Security Managers to their RDS Instance. (qs-1ngr590j9)'
 Parameters:
   AWSIVPC:

--- a/templates/common/sps.template
+++ b/templates/common/sps.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.31: Smart protection server template (qs-1ngr590jj).
+  v5.32: Smart protection server template (qs-1ngr590jj).
 Parameters:
   AWSIKeyPairName:
     Description: Existing key pair to use for connecting to your Smart Protection Server

--- a/templates/marketplace/dsm-mp.template
+++ b/templates/marketplace/dsm-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: Deploys Deep Security Manager to AWS. This template is designed
+Description: 'v5.32: Deploys Deep Security Manager to AWS. This template is designed
   to be nested in a stack, and requires several passed parameters to launch. **WARNING**
   This template creates Amazon EC2 instances and related resources. You will be billed
   for the AWS resources used if you create a stack from this template. (qs-1ngr590jo)'
@@ -218,62 +218,62 @@ Parameters:
 Mappings:
   DSMAMI:
     ap-northeast-1:
-      PerHost: ami-0eb8fc8bcc4151184
-      BYOL: ami-065066e785990b8f8
+      PerHost: ami-0108b5e93819995cf
+      BYOL: ami-05a5094e17282c4ae
     ap-northeast-2:
-      PerHost: ami-0a5c1a8b409581dc5
-      BYOL: ami-0d1e9d26650ed90e9
+      PerHost: ami-045ffa75a6123665b
+      BYOL: ami-01b2869c88125bf3a
     ap-south-1:
-      PerHost: ami-01c86b761e6a317e1
-      BYOL: ami-0f7c1004963c91f40
+      PerHost: ami-0bb4a0a0afa84515e
+      BYOL: ami-03f47074666ac3b22
     ap-southeast-1:
-      PerHost: ami-05edde9391cb8d0b8
-      BYOL: ami-0d4b01d970fe7cc89
+      PerHost: ami-05d5005643407898a
+      BYOL: ami-05ebda1f31a3875c5
     ap-southeast-2:
-      PerHost: ami-0c8ecb6b21d2bd278
-      BYOL: ami-05f629cc2a737ccbb
+      PerHost: ami-06594eb53ce7b403b
+      BYOL: ami-0414cb34ff9164c97
     ca-central-1:
-      PerHost: ami-0deb5bac6addd6618
-      BYOL: ami-0d1574856370f199b
-    eu-north-1:
-      PerHost: ami-0bb0f0d9a26fd6062
-      BYOL: ami-04b9d986f28d83687
+      PerHost: ami-00c9767dc6edde5da
+      BYOL: ami-02fb9ff785d2f4471
     eu-central-1:
-      PerHost: ami-0f33a06ec27b209ed
-      BYOL: ami-03450e4e48aa3af25
+      PerHost: ami-0a9ddefd7a924ac66
+      BYOL: ami-00fe2065fc44f20d8
+    eu-north-1:
+      PerHost: ami-04c1c0bda16e81cb1
+      BYOL: ami-0b5f1cc0741085214
     eu-west-1:
-      PerHost: ami-05e472bdbb5ce7bb1
-      BYOL: ami-0d8f1abcc01eb524a
+      PerHost: ami-0922ba3bb85e1246d
+      BYOL: ami-03d26449f81118a4d
     eu-west-2:
-      PerHost: ami-07e41aecaed04d884
-      BYOL: ami-0787c9e0feb5f687f
+      PerHost: ami-002e4ffb17dc10657
+      BYOL: ami-07cc9e5fcac0ac34e
     eu-west-3:
-      PerHost: ami-0692165847deb8e46
-      BYOL: ami-0e27aaf6d8e86dfed
-    sa-east-1:
-      PerHost: ami-06bb4e95975e42414
-      BYOL: ami-01dc310042055eb58
-    us-east-1:
-      PerHost: ami-06b61abd05e4c9898
-      BYOL: ami-0648927d9960d339c
-    us-east-2:
-      PerHost: ami-0c8c51eed1ffbea76
-      BYOL: ami-09e6c029444bf13c2
-    us-gov-west-1:
-      PerHost: ami-0e34a3ee2bd47f4b8
-      BYOL: ami-0dce04e5df49a6f51
-    us-west-1:
-      PerHost: ami-000ddf98080478263
-      BYOL: ami-0a90e5404685326d6
-    us-west-2:
-      PerHost: ami-033725455e09fa1f9
-      BYOL: ami-06104c55cbc4c094d
+      PerHost: ami-0f798710e57bc9618
+      BYOL: ami-06f3e0e3a153a8d2e
     me-south-1:
-      PerHost: ami-0e33e3059c632275c
-      BYOL: ami-0e8a2b0d35e0d9564
+      PerHost: ami-0c4e7de8d8a2088d8
+      BYOL: ami-0cc42a653d9f076ab
+    sa-east-1:
+      PerHost: ami-0f998052d38a3096a
+      BYOL: ami-0c4dd3425b83088f2
+    us-east-1:
+      PerHost: ami-03d5316ee012a9e7f
+      BYOL: ami-06b06d2555bda46b9
+    us-east-2:
+      PerHost: ami-0a965d402e91a6a80
+      BYOL: ami-0352ffff22344f0a5
     us-gov-east-1:
-      PerHost: ami-0c5f9fddf5d23f3b8
-      BYOL: ami-0d662550008dc65c8
+      PerHost: ami-0f5b4986b49ecaf67
+      BYOL: ami-04043e7ea8e1968fd
+    us-gov-west-1:
+      PerHost: ami-04c31a2998349ecc8
+      BYOL: ami-0b4ce4d3e17676a9c
+    us-west-1:
+      PerHost: ami-009c1c5db0eab8f6d
+      BYOL: ami-0f0bc62d74dbecf76
+    us-west-2:
+      PerHost: ami-087eabe2877768784
+      BYOL: ami-04e1fbc3ed1381def
   DSMSIZE:
     us-east-1:
       PerHost: m5.xlarge
@@ -537,6 +537,9 @@ Resources:
                   ${softwareUpdateScreenProxyConfig}
                   ${securityUpdateScreenProxyConfig}
                   Override.Automation=True
+                  Cloudformation.QSS3BucketName=${QSS3BucketName}
+                  Cloudformation.QSS3BucketRegion=${QSS3BucketRegion}
+                  Cloudformation.QSS3KeyPrefix=${QSS3KeyPrefix}
                 - LicenseConfig:
                     !If
                     - AddAcAnswer

--- a/templates/marketplace/master-mp.template
+++ b/templates/marketplace/master-mp.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: Trend Micro Deep Security Marketplace master template. For more
+Description: 'v5.32: Trend Micro Deep Security Marketplace master template. For more
   information see http://aws.trendmicro.com. (qs-1ngr590jt)'
 Metadata:
   AWS::CloudFormation::Interface:

--- a/templates/quickstart/Infrastructure.template
+++ b/templates/quickstart/Infrastructure.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: Template for testing the Quick Start, Creates the VPCs
+Description: 'v5.32: Template for testing the Quick Start, Creates the VPCs
   and subnets needed for deployment'
 Parameters:
   EnableDNSHostNames:

--- a/templates/quickstart/trendmicro-deepsecurity-byol-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-byol-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.31: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.32: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ RDS instance  **WARNING** This template uses
   images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-demo.template
+++ b/templates/quickstart/trendmicro-deepsecurity-demo.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'DEMO ONLY - v5.31: Demo of the Trend Micro Deep Security Quick Start.
+Description: 'DEMO ONLY - v5.32: Demo of the Trend Micro Deep Security Quick Start.
   This template creates the VPC infrastructure needed for the Quick Start and deploys an
   EC2 instance with Docker and PostgreSQL for the database. **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please

--- a/templates/quickstart/trendmicro-deepsecurity-master.template
+++ b/templates/quickstart/trendmicro-deepsecurity-master.template
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'QS(0011) - v5.31: Quick Start that deploys Trend Micro Deep Security
+Description: 'QS(0011) - v5.32: Quick Start that deploys Trend Micro Deep Security
   into an existing VPC with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template
   uses images from the AWS Marketplace and an active subscription is required - Please
   see the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/quickstart/trendmicro-deepsecurity-rhel.template
+++ b/templates/quickstart/trendmicro-deepsecurity-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.31: Quick Start that deploys Trend Micro Deep Security into an existing VPC
+  v5.32: Quick Start that deploys Trend Micro Deep Security into an existing VPC
   with a Multi-AZ PostgreSQL RDS instance  **WARNING** This template uses images
   from the AWS Marketplace and an active subscription is required - Please see
   the Quick Start documentation for more details. You will be billed for the AWS

--- a/templates/rhel/dsm-rhel.template
+++ b/templates/rhel/dsm-rhel.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
-  v5.31: Deploys Deep Security Manager to AWS. This template is designed to be
+  v5.32: Deploys Deep Security Manager to AWS. This template is designed to be
   nested in a stack, and requires several passed parameters to launch.
   **WARNING** This template creates Amazon EC2 instances and related resources.
   You will be billed for the AWS resources used if you create a stack from this
@@ -597,6 +597,18 @@ Resources:
                     RelayScreen.ProxyAuthentication=False
                   - |
                     Override.Automation=True
+                  - Cloudformation.QSS3BucketName=
+                  - !Ref QSS3BucketName
+                  - |+
+
+                  - Cloudformation.QSS3BucketRegion=
+                  - !Ref QSS3BucketRegion
+                  - |+
+
+                  - Cloudformation.QSS3KeyPrefix=
+                  - !Ref QSS3KeyPrefix
+                  - |+    
+
               owner: root
               mode: '000600'
         installDSM:

--- a/templates/rhel/master-rhel.template
+++ b/templates/rhel/master-rhel.template
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: 'v5.31: Trend Micro Deep Security AWS RHEL master template.'
+Description: 'v5.32: Trend Micro Deep Security AWS RHEL master template.'
 Metadata:
   'AWS::CloudFormation::Interface':
     ParameterGroups:


### PR DESCRIPTION
- Update AMI ID for Deep Security 20 Release
- Change oracle RDS version to 19.0.0.0.ru-2020-04.rur-2020-04.r1 with engine oracle-se2
- Remove unsupported oracle RDS instance type